### PR TITLE
(refactor)types: include application kind into chaosengine spec

### DIFF
--- a/deploy/crds/chaosengine.yaml
+++ b/deploy/crds/chaosengine.yaml
@@ -20,6 +20,7 @@ spec:
   appinfo: 
     appns: default
     applabel: "app=nginx"
+    appkind: deployment
   
   ## The chaos experiments themselves will be "pulled" via
   ## downloadable litmus charts and versioned against it

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -32,6 +32,8 @@ type ApplicationParams struct {
         Appns          string               `json:"appns"`
         //Unique label of the AUT
         Applabel       string               `json:"applabel"`
+        //Kubernetes resource type of AUT
+        Appkind        string               `json:"appkind"`
 }
 
 // ExperimentList defines information about chaos experiments defined in the chaos engine


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Includes information about application resource type in the chaosengine schema (deployment, statefulset, daemonset). This will aid filtering the application chaos candidates and deriving the application UUID. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] Labelled this PR & related issue with `documentation` tag
