### PR TITLE
(refactor)operator: implement builder pattern for building secondary resources

### DIFF
--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -1,16 +1,20 @@
 package chaosengine
 
 import (
-        "strings"
 	"context"
-        "fmt"
+	"fmt"
+	"strings"
+
 	litmuschaosv1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	container "github.com/litmuschaos/chaos-operator/pkg/kubernetes/containers"
+	pod "github.com/litmuschaos/chaos-operator/pkg/kubernetes/pod"
+	service "github.com/litmuschaos/chaos-operator/pkg/kubernetes/service"
 	corev1 "k8s.io/api/core/v1"
-        "k8s.io/client-go/kubernetes"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -20,16 +24,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
-        // Temp test purposes
-        //"github.com/Sirupsen/logrus"
+	// Temp test purposes
+	//"github.com/Sirupsen/logrus"
 )
 
 var log = logf.Log.WithName("controller_chaosengine")
 
-// Annotations on app to enable chaos on it 
+// Annotations on app to enable chaos on it
 const (
-      chaosAnnotation  = "litmuschaos.io/chaos"
+	chaosAnnotation = "litmuschaos.io/chaos"
 )
 
 /**
@@ -109,95 +112,101 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Fetch the app details from ChaosEngine instance. Check if app is present
-        // Also check, if the app is annotated for chaos & that the labels are unique
+	// Also check, if the app is annotated for chaos & that the labels are unique
 
-        // TODO: Get app kind from chaosengine spec as well. Using "deploy" for now
-        // TODO: Freeze label format in chaosengine( "=" as a const)
+	// TODO: Get app kind from chaosengine spec as well. Using "deploy" for now
+	// TODO: Freeze label format in chaosengine( "=" as a const)
 
-        aLabelKeyValue := strings.Split(instance.Spec.Appinfo.Applabel, "=")
-        lKey := aLabelKeyValue[0]; lValue := aLabelKeyValue[1]
-        aLabel := make(map[string]string); aLabel[lKey] = lValue
-        aNamespace := instance.Spec.Appinfo.Appns
-        aExpList := instance.Spec.Experiments 
+	aLabelKeyValue := strings.Split(instance.Spec.Appinfo.Applabel, "=")
+	lKey := aLabelKeyValue[0]
+	lValue := aLabelKeyValue[1]
+	aLabel := make(map[string]string)
+	aLabel[lKey] = lValue
+	aNamespace := instance.Spec.Appinfo.Appns
+	aExpList := instance.Spec.Experiments
 
-        var appExperiments []string
-        for _, exp := range aExpList {
-          appExperiments = append(appExperiments, exp.Name)
-        }
-
-        // Temp test purposes
-        /*
-        logrus.Info("App Label derived from Chaosengine is ", aLabel)
-        logrus.Info("App NS derived from Chaosengine is ", aNamespace)
-        logrus.Info("Exp list derived from chaosengine is ", appExperiments)
-        */
-
-        log.Info("App Label derived from Chaosengine is ", aLabel)
-        log.Info("App NS derived from Chaosengine is ", aNamespace)
-        log.Info("Exp list derived from chaosengine is ", appExperiments)
-
-        // Use client-Go to obtain a list of apps w/ specified labels 
-        config, err := config.GetConfig()
-        if err != nil {
-	  //logrus.Fatal(err.Error())
-	  log.Error(err, "unable to get kube config")
-          return reconcile.Result{}, err
+	var appExperiments []string
+	for _, exp := range aExpList {
+		appExperiments = append(appExperiments, exp.Name)
 	}
 
-        clientset, err := kubernetes.NewForConfig(config)
-        if err != nil {
-	  //logrus.Fatal(err.Error())
-          log.Error(err, "unable to create clientset using kubeconfig")
-          return reconcile.Result{}, err
+	// Temp test purposes
+	/*
+	   logrus.Info("App Label derived from Chaosengine is ", aLabel)
+	   logrus.Info("App NS derived from Chaosengine is ", aNamespace)
+	   logrus.Info("Exp list derived from chaosengine is ", appExperiments)
+	*/
+
+	log.Info("App Label derived from Chaosengine is ", aLabel)
+	log.Info("App NS derived from Chaosengine is ", aNamespace)
+	log.Info("Exp list derived from chaosengine is ", appExperiments)
+
+	// Use client-Go to obtain a list of apps w/ specified labels
+	config, err := config.GetConfig()
+	if err != nil {
+		//logrus.Fatal(err.Error())
+		log.Error(err, "unable to get kube config")
+		return reconcile.Result{}, err
 	}
 
-        cApp, err := clientset.AppsV1().Deployments(aNamespace).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", lKey, lValue), FieldSelector: ""})
-        if err != nil {
-          //logrus.Fatal("Failed to list deployments. Error is ", err)
-          log.Error(err, "unable to list apps matching labels")
-          return reconcile.Result{}, err
-        }
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		//logrus.Fatal(err.Error())
+		log.Error(err, "unable to create clientset using kubeconfig")
+		return reconcile.Result{}, err
+	}
 
-        var appName string
-        var appUUID types.UID
+	cApp, err := clientset.AppsV1().Deployments(aNamespace).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", lKey, lValue), FieldSelector: ""})
+	if err != nil {
+		//logrus.Fatal("Failed to list deployments. Error is ", err)
+		log.Error(err, "unable to list apps matching labels")
+		return reconcile.Result{}, err
+	}
 
-        // Determine whether apps with matching labels have chaos annotation set to true
-        chaosCandidates := 0
-        if len(cApp.Items) > 0 {
-          for _, app := range cApp.Items {
-            appName = app.ObjectMeta.Name
-            appUUID = app.ObjectMeta.UID
-            appCaSts := metav1.HasAnnotation(app.ObjectMeta, chaosAnnotation)
-            //if appCaSts == true {
-            if appCaSts {
-              //logrus.Info ("chaos candidate app: ", appName, appUUID)
-              log.Info ("chaos candidate app: ", appName, appUUID)
-              chaosCandidates++
-            }
-          }
-          if chaosCandidates == 0 {
-            //logrus.Info("No chaos candidates found")
-            log.Info("No chaos candidates found")
-            return reconcile.Result{}, nil
-          } else if chaosCandidates > 1 {
-            //logrus.Info ("Too many chaos candidates with same label",
-            log.Info ("Too many chaos candidates with same label",
-              "either provide unique labels or annotate only desired app for chaos",)
-            return reconcile.Result{}, nil
-          }
-        } else {
-          //logrus.Info("No app deployments with matching labels")
-          log.Info("No app deployments with matching labels")
-          return reconcile.Result{}, nil
-        }
+	var appName string
+	var appUUID types.UID
 
-        // Define an engine(ansible?)-runner pod which is secondary-resource #1 
-        engineRunner := newRunnerPodForCR(instance, appUUID, appExperiments)
+	// Determine whether apps with matching labels have chaos annotation set to true
+	chaosCandidates := 0
+	if len(cApp.Items) > 0 {
+		for _, app := range cApp.Items {
+			appName = app.ObjectMeta.Name
+			appUUID = app.ObjectMeta.UID
+			appCaSts := metav1.HasAnnotation(app.ObjectMeta, chaosAnnotation)
+			//if appCaSts == true {
+			if appCaSts {
+				//logrus.Info ("chaos candidate app: ", appName, appUUID)
+				log.Info("chaos candidate app: ", appName, appUUID)
+				chaosCandidates++
+			}
+		}
+		if chaosCandidates == 0 {
+			//logrus.Info("No chaos candidates found")
+			log.Info("No chaos candidates found")
+			return reconcile.Result{}, nil
+		} else if chaosCandidates > 1 {
+			//logrus.Info ("Too many chaos candidates with same label",
+			log.Info("Too many chaos candidates with same label",
+				"either provide unique labels or annotate only desired app for chaos")
+			return reconcile.Result{}, nil
+		}
+	} else {
+		//logrus.Info("No app deployments with matching labels")
+		log.Info("No app deployments with matching labels")
+		return reconcile.Result{}, nil
+	}
 
-        // Define the engine-monitor service which is secondary-resource #2
-        engineMonitor := newMonitorServiceForCR(instance)
-
-	// Set ChaosEngine instance as the owner and controller of engine-runner pod 
+	// Define an engine(ansible?)-runner pod which is secondary-resource #1
+	engineRunner, err := newRunnerPodForCR(instance, appUUID, appExperiments)
+	if err != nil {
+		return reconcile.Result{}, nil
+	}
+	// Define the engine-monitor service which is secondary-resource #2
+	engineMonitor, err := newMonitorServiceForCR(instance)
+	if err != nil {
+		return reconcile.Result{}, nil
+	}
+	// Set ChaosEngine instance as the owner and controller of engine-runner pod
 	if err := controllerutil.SetControllerReference(instance, engineRunner, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -207,7 +216,7 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
-        // Check if the engineRunner pod already exists, else create
+	// Check if the engineRunner pod already exists, else create
 	foundS1 := &corev1.Pod{} //secondary resource #1
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: engineRunner.Name, Namespace: engineRunner.Namespace}, foundS1)
 	if err != nil && errors.IsNotFound(err) {
@@ -218,7 +227,7 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 		}
 
 		// Pod created successfully - don't requeue
-                reqLogger.Info("engineRunner Pod created successfully")
+		reqLogger.Info("engineRunner Pod created successfully")
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -226,7 +235,7 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 	// Pod already exists - don't requeue
 	reqLogger.Info("Skip reconcile: engineRunner Pod already exists", "Pod.Namespace", foundS1.Namespace, "Pod.Name", foundS1.Name)
 
-        // Check if the engineMonitorservice already exists, else create
+	// Check if the engineMonitorservice already exists, else create
 	foundS2 := &corev1.Service{} //secondary resource #2
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: engineMonitor.Name, Namespace: engineMonitor.Namespace}, foundS2)
 	if err != nil && errors.IsNotFound(err) {
@@ -247,87 +256,92 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 	return reconcile.Result{}, nil /*You can return now, both sec resources are existing */
 }
 
-
 // newRunnerPodForCR defines secondary resource #1 in same namespace as CR */
-func newRunnerPodForCR(cr *litmuschaosv1alpha1.ChaosEngine, aUUID types.UID, aExList []string) *corev1.Pod {
+func newRunnerPodForCR(cr *litmuschaosv1alpha1.ChaosEngine, aUUID types.UID, aExList []string) (*corev1.Pod, error) {
 	labels := map[string]string{
 		"app": cr.Name,
 	}
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-runner",
-			Namespace: cr.Namespace,
-			Labels:    labels,
-		},
-		Spec: corev1.PodSpec{
-                        ServiceAccountName: "chaos-operator",
-			Containers: []corev1.Container{
-				{
-					Name:    "chaos-runner",
-					Image:   "openebs/ansible-runner:ci",
-					Command: []string{"/bin/bash"},
-                                        //TODO: Reconcile will restart tests. This has to be addressed 
-                                        Args:    []string{"-c", "ansible-playbook ./executor/test.yml -i /etc/ansible/hosts -vv; exit 0"},
-                                        Env:     []corev1.EnvVar{
-                                             {
-                                                 Name: "CHAOSENGINE",
-                                                 Value: cr.Name,
-                                             },
-                                             {
-                                                 Name: "APP_LABEL",
-                                                 Value: cr.Spec.Appinfo.Applabel,
-                                             },
-                                             {
-                                                 Name: "APP_NAMESPACE",
-                                                 Value: cr.Namespace,
-                                             },
-                                             {
-                                                 Name: "EXPERIMENT_LIST",
-                                                 //Value: fmt.Sprintf(strings.Join(aExList,",")),
-                                                 Value: fmt.Sprint(strings.Join(aExList,",")),
-                                             },
-				         },
-                                },
-				{
-					Name:    "chaos-exporter",
-					Image:   "litmuschaos/chaos-exporter:ci",
-                                        Env:     []corev1.EnvVar{
-                                            {
-                                                 Name: "CHAOSENGINE",
-                                                 Value: cr.Name,
-                                            },
-                                            {
-                                                 Name: "APP_UUID",
-                                                 Value: string(aUUID),
-                                            },
-                                        },
-				},
-			},
-		},
+	podObj, err := pod.NewBuilder().
+		WithName(cr.Name + "-runner").
+		WithNamespace(cr.Namespace).
+		WithLabels(labels).
+		WithServiceAccountName("chaos-operator").
+		WithContainerBuilder(
+			container.NewBuilder().
+				WithName("chaos-runner").
+				WithImage("ksatchit/ansible-runner:trial8").
+				WithCommandNew([]string{"/bin/bash"}).
+				WithArgumentsNew([]string{"-c", "ansible-playbook ./executor/test.yml -i /etc/ansible/hosts -vv; exit 0"}).
+				WithEnvsNew(
+					[]corev1.EnvVar{
+						{
+							Name:  "CHAOSENGINE",
+							Value: cr.Name,
+						},
+						{
+							Name:  "APP_LABEL",
+							Value: cr.Spec.Appinfo.Applabel,
+						},
+						{
+							Name:  "APP_NAMESPACE",
+							Value: cr.Namespace,
+						},
+						{
+							Name: "EXPERIMENT_LIST",
+							//Value: fmt.Sprintf(strings.Join(aExList,",")),
+							Value: fmt.Sprint(strings.Join(aExList, ",")),
+						},
+					},
+				),
+		).
+		WithContainerBuilder(
+			container.NewBuilder().
+				WithName("chaos-exporter").
+				WithImage("litmuschaos/chaos-exporter:ci").
+				WithEnvsNew(
+					[]corev1.EnvVar{
+						{
+							Name:  "CHAOSENGINE",
+							Value: cr.Name,
+						},
+						{
+							Name:  "APP_UUID",
+							Value: string(aUUID),
+						},
+					},
+				),
+		).
+		Build()
+	if err != nil {
+		return nil, err
 	}
+	return podObj, nil
 }
 
 // newMonitorServiceForCR defines secondary resource #2 in same namespace as CR */
-func newMonitorServiceForCR(cr *litmuschaosv1alpha1.ChaosEngine) *corev1.Service {
+func newMonitorServiceForCR(cr *litmuschaosv1alpha1.ChaosEngine) (*corev1.Service, error) {
 	labels := map[string]string{
 		"app": cr.Name,
 	}
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-monitor",
-			Namespace: cr.Namespace,
-			Labels:    labels,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
+	serviceObj, err := service.NewBuilder().
+		WithName(cr.Name + "-monitor").
+		WithNamespace(cr.Namespace).
+		WithLabels(labels).
+		WithPorts(
+			[]corev1.ServicePort{
 				{
-					Name:    "metrics",
-					Port:    8080,
+					Name: "metrics",
+					Port: 8080,
 				},
 			},
-                        Selector: map[string]string{
-                                "app": cr.Name,
-                        },
-		},
+		).
+		WithSelectorsNew(
+			map[string]string{
+				"app": cr.Name,
+			}).
+		Build()
+	if err != nil {
+		return nil, err
 	}
+	return serviceObj, nil
 }

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -272,8 +272,7 @@ func getChaosRunnerENV(cr *litmuschaosv1alpha1.ChaosEngine, aExList []string) []
 			Value: cr.Namespace,
 		},
 		{
-			Name: "EXPERIMENT_LIST",
-			//Value: fmt.Sprintf(strings.Join(aExList,",")),
+			Name:  "EXPERIMENT_LIST",
 			Value: fmt.Sprint(strings.Join(aExList, ",")),
 		},
 	}

--- a/pkg/kubernetes/containers/build.go
+++ b/pkg/kubernetes/containers/build.go
@@ -6,6 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// Builder is the builder object for container
 type Builder struct {
 	con    *container // container instance
 	errors []error    // errors found while building the container instance

--- a/pkg/kubernetes/containers/build.go
+++ b/pkg/kubernetes/containers/build.go
@@ -1,0 +1,138 @@
+package containers
+
+import (
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Builder struct {
+	con    *container // container instance
+	errors []error    // errors found while building the container instance
+}
+
+// NewBuilder returns a new instance of builder
+func NewBuilder() *Builder {
+	return &Builder{
+		con: &container{},
+	}
+}
+
+// validate will run checks against container instance
+func (b *Builder) validate() error {
+
+	if len(b.errors) == 0 {
+		return nil
+	}
+	return errors.New("failed")
+}
+
+// Build returns the final kubernetes container
+func (b *Builder) Build() (corev1.Container, error) {
+	err := b.validate()
+	if err != nil {
+		return corev1.Container{}, err
+	}
+	return b.con.object, nil
+}
+
+// WithName sets the name of the container
+func (b *Builder) WithName(name string) *Builder {
+	if len(name) == 0 {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: missing name"),
+		)
+		return b
+	}
+	b.con.object.Name = name
+	return b
+}
+
+// WithImage sets the image of the container
+func (b *Builder) WithImage(img string) *Builder {
+	if len(img) == 0 {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: missing image"),
+		)
+		return b
+	}
+	b.con.object.Image = img
+	return b
+}
+
+// WithCommandNew sets the command of the container
+func (b *Builder) WithCommandNew(cmd []string) *Builder {
+	if cmd == nil {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: nil command"),
+		)
+		return b
+	}
+
+	if len(cmd) == 0 {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: missing command"),
+		)
+		return b
+	}
+
+	newcmd := []string{}
+	newcmd = append(newcmd, cmd...)
+
+	b.con.object.Command = newcmd
+	return b
+}
+
+// WithArgumentsNew sets the command arguments of the container
+func (b *Builder) WithArgumentsNew(args []string) *Builder {
+	if args == nil {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: nil arguments"),
+		)
+		return b
+	}
+
+	if len(args) == 0 {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: missing arguments"),
+		)
+		return b
+	}
+
+	newargs := []string{}
+	newargs = append(newargs, args...)
+
+	b.con.object.Args = newargs
+	return b
+}
+
+// WithEnvsNew sets the envs of the container
+func (b *Builder) WithEnvsNew(envs []corev1.EnvVar) *Builder {
+	if envs == nil {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: nil envs"),
+		)
+		return b
+	}
+
+	if len(envs) == 0 {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: missing envs"),
+		)
+		return b
+	}
+
+	newenvs := []corev1.EnvVar{}
+	newenvs = append(newenvs, envs...)
+
+	b.con.object.Env = newenvs
+	return b
+}

--- a/pkg/kubernetes/containers/containers.go
+++ b/pkg/kubernetes/containers/containers.go
@@ -1,0 +1,9 @@
+package containers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type container struct {
+	object corev1.Container
+}

--- a/pkg/kubernetes/pod/build.go
+++ b/pkg/kubernetes/pod/build.go
@@ -1,0 +1,108 @@
+package pod
+
+import (
+	"errors"
+	"fmt"
+
+	container "github.com/litmuschaos/chaos-operator/pkg/kubernetes/containers"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Builder is the builder object for Pod
+type Builder struct {
+	pod  *Pod
+	errs []error
+}
+
+// NewBuilder returns new instance of Builder
+func NewBuilder() *Builder {
+	return &Builder{pod: &Pod{object: &corev1.Pod{}}}
+}
+
+// WithName sets the Name field of Pod with provided value.
+func (b *Builder) WithName(name string) *Builder {
+	if len(name) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing Pod name"),
+		)
+		return b
+	}
+	b.pod.object.Name = name
+	return b
+}
+
+// WithNamespace sets the Namespace field of Pod with provided value.
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	if len(namespace) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing namespace"),
+		)
+		return b
+	}
+	b.pod.object.Namespace = namespace
+	return b
+}
+
+// WithLabels sets the labels field of Pod with provided value
+func (b *Builder) WithLabels(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build pod object: missing labels"),
+		)
+		return b
+	}
+
+	if b.pod.object.Labels == nil {
+		b.pod.object.Labels = map[string]string{}
+	}
+
+	for key, value := range labels {
+		b.pod.object.Labels[key] = value
+	}
+	return b
+}
+
+// WithServiceAccountName sets the serviceaccountname field of Pod with provided value
+func (b *Builder) WithServiceAccountName(serviceaccountname string) *Builder {
+	if len(serviceaccountname) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing Pod serviceaccountname"),
+		)
+		return b
+	}
+	b.pod.object.Spec.ServiceAccountName = serviceaccountname
+	return b
+}
+
+// WithContainerBuilder adds a container to this pod object.
+//
+// NOTE:
+//   container details are present in the provided container
+// builder object
+func (b *Builder) WithContainerBuilder(
+	containerBuilder *container.Builder,
+) *Builder {
+	containerObj, err := containerBuilder.Build()
+	if err != nil {
+		b.errs = append(b.errs, fmt.Errorf("failed to build pod %v", err))
+		return b
+	}
+	b.pod.object.Spec.Containers = append(
+		b.pod.object.Spec.Containers,
+		containerObj,
+	)
+	return b
+}
+
+// Build returns the Pod API instance
+func (b *Builder) Build() (*corev1.Pod, error) {
+	if len(b.errs) > 0 {
+		return nil, fmt.Errorf("%+v", b.errs)
+	}
+	return b.pod.object, nil
+}

--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -8,8 +8,3 @@ import (
 type Pod struct {
 	object *corev1.Pod
 }
-
-// PodList holds the list of API pod instances
-type PodList struct {
-	items []*Pod
-}

--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -1,0 +1,15 @@
+package pod
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Pod holds the api's pod objects
+type Pod struct {
+	object *corev1.Pod
+}
+
+// PodList holds the list of API pod instances
+type PodList struct {
+	items []*Pod
+}

--- a/pkg/kubernetes/service/build.go
+++ b/pkg/kubernetes/service/build.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Builder is the builder object for Service
+type Builder struct {
+	service *Service
+	errs    []error
+}
+
+// NewBuilder returns new instance of Builder
+func NewBuilder() *Builder {
+	return &Builder{service: &Service{object: &corev1.Service{}}}
+}
+
+// WithName sets the Name field of Service with provided value.
+func (b *Builder) WithName(name string) *Builder {
+	if len(name) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.
+				New("failed to build service object: missing name"),
+		)
+		return b
+	}
+	b.service.object.Name = name
+	return b
+}
+
+// WithNamespace sets the Namespace field of Service provided arguments
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	if len(namespace) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.
+				New("failed to build service object: missing namespace"),
+		)
+		return b
+	}
+	b.service.object.Namespace = namespace
+	return b
+}
+
+// WithLabels sets the labels field of Service provided arguments
+func (b *Builder) WithLabels(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build service object: missing labels"),
+		)
+		return b
+	}
+
+	if b.service.object.Labels == nil {
+		b.service.object.Labels = map[string]string{}
+	}
+
+	for key, value := range labels {
+		b.service.object.Labels[key] = value
+	}
+	return b
+}
+
+// WithPorts sets the ports field of Service provided arguments
+func (b *Builder) WithPorts(ports []corev1.ServicePort) *Builder {
+	if len(ports) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build service object: missing ports"),
+		)
+		return b
+	}
+
+	// copy of original slice
+	newports := []corev1.ServicePort{}
+	newports = append(newports, ports...)
+
+	// override
+	b.service.object.Spec.Ports = newports
+	return b
+}
+
+// WithSelectorsNew resets existing selectors if any with
+// ones that are provided here
+func (b *Builder) WithSelectorsNew(selectors map[string]string) *Builder {
+	if len(selectors) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build service object: no new selectors"),
+		)
+		return b
+	}
+
+	// copy of original map
+	newslctrs := map[string]string{}
+	for key, value := range selectors {
+		newslctrs[key] = value
+	}
+
+	// override
+	b.service.object.Spec.Selector = newslctrs
+	return b
+}
+
+// Build returns the Service API instance
+func (b *Builder) Build() (*corev1.Service, error) {
+	if len(b.errs) > 0 {
+		return nil, fmt.Errorf("%+v", b.errs)
+	}
+	return b.service.object, nil
+}

--- a/pkg/kubernetes/service/service.go
+++ b/pkg/kubernetes/service/service.go
@@ -10,10 +10,3 @@ import (
 type Service struct {
 	object *corev1.Service
 }
-
-// ServiceList is a wrapper over service api
-// object. It provides build, validations and other common
-// logic to be used by various feature specific callers.
-type ServiceList struct {
-	items []*Service
-}

--- a/pkg/kubernetes/service/service.go
+++ b/pkg/kubernetes/service/service.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Service is a wrapper over service api
+// object. It provides build, validations and other common
+// logic to be used by various feature specific callers.
+type Service struct {
+	object *corev1.Service
+}
+
+// ServiceList is a wrapper over service api
+// object. It provides build, validations and other common
+// logic to be used by various feature specific callers.
+type ServiceList struct {
+	items []*Service
+}


### PR DESCRIPTION

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Implements  the "builder pattern" a way to construct the kubernetes specs for secondary resources `engine-runner` & `engine-monitor`. Provides a way to define resources in a cleaner and simpler manner.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests