### PR TITLE
(feat)operator: accept service account for chaos operations

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,7 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: chaos-operator
+  name: litmus
+  namespace: litmus
 spec:
   replicas: 1
   selector:
@@ -12,19 +13,17 @@ spec:
       labels:
         name: chaos-operator
     spec:
-      serviceAccountName: chaos-operator
+      serviceAccountName: litmus
       containers:
         - name: chaos-operator
           # Replace this with the built image name
-          image: REPLACE_IMAGE
+          image: litmuschaos/chaos-operator:ci
           command:
           - chaos-operator
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: 
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,17 +1,23 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: litmus
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: chaos-operator
+  name: litmus
+  namespace: litmus
   labels:
-    name: chaos-operator
+    name: litmus
 ---
+# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: chaos-operator
+  name: litmus
   labels:
-    name: chaos-operator
+    name: litmus
 rules:
 - apiGroups: ["*"]
   resources: ["*"]
@@ -20,13 +26,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: chaos-operator
+  name: litmus
   labels:
-    name: chaos-operator
+    name: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chaos-operator
+  name: litmus
 subjects:
 - kind: ServiceAccount
-  name: chaos-operator
+  name: litmus
+  namespace: litmus

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -11,6 +11,8 @@ import (
 type ChaosEngineSpec struct {
 	//Appinfo contains deployment details of AUT
 	Appinfo ApplicationParams `json:"appinfo"`
+	//ChaosServiceAccount is the SvcAcc specified for chaos runner pods
+	ChaosServiceAccount       string    `json:"chaosServiceAccount"`
 	//Consists of experiments executed by the engine
 	Experiments []ExperimentList `json:"experiments"`
 	//Execution schedule of batch of chaos experiments


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Accepts service account for chaos operations from chaosengine spec. This will enable users to define the scope & capability of the chaos-runner. 
- Update the operator & rbac manifests to ensure the default working namespace of operator is litmus

NOTE: Ensure that the service account provided has sufficient privileges to access the resources belonging to group litmuschaos.io 
 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests