### PR TITLE
unit test for initializeApplicationInfo in chaosengine_controller

### DIFF
--- a/pkg/controller/chaosengine/chaosengine_contoller_test.go
+++ b/pkg/controller/chaosengine/chaosengine_contoller_test.go
@@ -1,6 +1,7 @@
 package chaosengine
 
 import (
+	"fmt"
 	"testing"
 
 	litmuschaosv1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
@@ -100,6 +101,56 @@ func TestNewMonitorServiceForCR(t *testing.T) {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
 			if !mock.isErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+func TestInitializeApplicationInfo(t *testing.T) {
+	tests := map[string]struct {
+		instance       *litmuschaosv1alpha1.ChaosEngine
+		namespace      string
+		label          map[string]string
+		experimentList []litmuschaosv1alpha1.ExperimentList
+		isErr          bool
+	}{
+		"Test Positive": {
+			instance: &litmuschaosv1alpha1.ChaosEngine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-monitor",
+					Namespace: "test",
+				},
+				Spec: litmuschaosv1alpha1.ChaosEngineSpec{
+					Appinfo: litmuschaosv1alpha1.ApplicationParams{
+						Applabel: "key=value",
+					},
+				},
+			},
+			isErr: false,
+		},
+		"Test Negative": {
+			instance: nil,
+			isErr:    true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			appInfo := &applicationInfo{
+				namespace: "namespace",
+				label:     map[string]string{"fake_id": "aa"},
+				experimentList: []litmuschaosv1alpha1.ExperimentList{
+					{
+						Name: "fake_name",
+					},
+				},
+			}
+			_, err := appInfo.initializeApplicationInfo(mock.instance)
+			if mock.isErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.isErr && err != nil {
+				fmt.Println(err)
 				t.Fatalf("Test %q failed: expected error to be nil", name)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>
Implemented unit test for initializeApplicationInfo function in chaosengine_controller.
Result of Unit Test -:
```
=== RUN   TestNewRunnerPodForCR
=== RUN   TestNewRunnerPodForCR/Test_Positive
=== RUN   TestNewRunnerPodForCR/Test_Negative-1
=== RUN   TestNewRunnerPodForCR/Test_Negative-2_
=== RUN   TestNewRunnerPodForCR/Test_Negative-3_
--- FAIL: TestNewRunnerPodForCR (0.00s)
    --- FAIL: TestNewRunnerPodForCR/Test_Positive (0.00s)
        chaosengine_contoller_test.go:69: Test "Test Positive" failed: expected error to be nil
    --- PASS: TestNewRunnerPodForCR/Test_Negative-1 (0.00s)
    --- PASS: TestNewRunnerPodForCR/Test_Negative-2_ (0.00s)
    --- PASS: TestNewRunnerPodForCR/Test_Negative-3_ (0.00s)
=== RUN   TestNewMonitorServiceForCR
=== RUN   TestNewMonitorServiceForCR/Test_Negative
=== RUN   TestNewMonitorServiceForCR/Test_Positive
--- PASS: TestNewMonitorServiceForCR (0.00s)
    --- PASS: TestNewMonitorServiceForCR/Test_Negative (0.00s)
    --- PASS: TestNewMonitorServiceForCR/Test_Positive (0.00s)
=== RUN   TestInitializeApplicationInfo
=== RUN   TestInitializeApplicationInfo/Test_Negative
=== RUN   TestInitializeApplicationInfo/Test_Positive
--- PASS: TestInitializeApplicationInfo (0.00s)
    --- PASS: TestInitializeApplicationInfo/Test_Negative (0.00s)
    --- PASS: TestInitializeApplicationInfo/Test_Positive (0.00s)

```

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests