### PR TITLE
(bug): Fix circle-ci build error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
   build:
     machine:
         image: circleci/classic:201808-01
-        docker_layer_caching: true
     environment:
       K8S_VERSION: v1.12.0
       KUBECONFIG: /home/circleci/.kube/config


### PR DESCRIPTION
Signed-off-by: chandan kumar <chandan.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This will fix the circle ci build issue, i.e:
```
#!/bin/sh -eo pipefail
# Blocked due to free-plan-docker-layer-caching-unavailable
# 
# -------
# Warning: This configuration was auto-generated to show you the message above.
# Don't rerun this job. Rerunning will have no effect.
false
Exited with code 1
```

**Which issue this PR fixes**  #67

**Special notes for your reviewer**:

**Checklist:**
- [x] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests