### PR TITLE
fix:(area/monitoring) Add unique label for exporter pod

### DIFF
--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -333,7 +333,7 @@ func newMonitorPodForCR(engine chaosTypes.EngineInfo) (*corev1.Pod, error) {
 		return nil, errors.New("chaosengine got nil")
 	}
 	labels := map[string]string{
-		"app":        engine.Instance.Name,
+		"app":        "chaos-exporter",
 		"monitorFor": engine.Instance.Name,
 	}
 	monitorPod, err := pod.NewBuilder().
@@ -359,25 +359,15 @@ func newMonitorPodForCR(engine chaosTypes.EngineInfo) (*corev1.Pod, error) {
 
 // newMonitorServiceForCR defines secondary resource #2 in same namespace as CR */
 func newMonitorServiceForCR(engine chaosTypes.EngineInfo) (*corev1.Service, error) {
-
 	if engine.Instance == nil {
 		return nil, errors.New("nil chaosengine object")
-	}
-	labels := map[string]string{
-		"app":        engine.Instance.Name,
-		"monitorFor": engine.Instance.Name,
 	}
 	serviceObj, err := service.NewBuilder().
 		WithName(engine.Instance.Name + "-monitor").
 		WithNamespace(engine.Instance.Namespace).
-		WithLabels(labels).
+		WithLabels(map[string]string{"app": "chaos-exporter"}).
 		WithPorts(getMonitoringENV()).
-		WithSelectorsNew(
-			map[string]string{
-				"app":        engine.Instance.Name,
-				"monitorFor": engine.Instance.Name,
-			}).
-		Build()
+		WithSelectorsNew(map[string]string{"monitorFor": engine.Instance.Name}).Build()
 	if err != nil {
 		return nil, err
 	}
@@ -472,7 +462,7 @@ func (r *ReconcileChaosEngine) getChaosEngineInstance(request reconcile.Request)
 }
 
 // Get application details
-func getApplicationDetail(ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo , error) {
+func getApplicationDetail(ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, error) {
 	applicationInfo := &chaosTypes.ApplicationInfo{}
 	appInfo, err := initializeApplicationInfo(ce.Instance, applicationInfo)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: chandan kumar <chandan.kr404@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This change is required to scrape the metrics exporter pod by Prometheus.
Note: Prometheus is looking for the pod with label `chaos-exporter`.

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests