### PR TITLE
(refactor)build: ensure 'latest' tag corresponds to release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       CHANGE_MINIKUBE_NONE_USER: true
       REPONAME: litmuschaos
       IMGNAME: chaos-operator
-      IMGTAG: latest
+      IMGTAG: ci
     steps:
       - checkout
       - run:
@@ -41,7 +41,7 @@ jobs:
             echo 'export PATH="$GOPATH/bin:$PATH"' >> workspace/env-vars
             echo 'export REPONAME="litmuschaos"' >> workspace/env-vars
             echo 'export IMGNAME="chaos-operator"' >> workspace/env-vars
-            echo 'export IMGTAG="latest"' >> workspace/env-vars
+            echo 'export IMGTAG="ci"' >> workspace/env-vars
             cat workspace/env-vars >> $BASH_ENV
             source $BASH_ENV
       - run: make deps
@@ -61,7 +61,7 @@ jobs:
     machine: 
       image: circleci/classic:201808-01
     environment:
-      IMGTAG: latest
+      IMGTAG: ci
     working_directory: ~/go/src/github.com/litmuschaos/chaos-operator
     steps: 
       - attach_workspace:
@@ -77,7 +77,7 @@ jobs:
     machine: 
       image: circleci/classic:201808-01
     environment:
-      IMGTAG: latest
+      IMGTAG: ci
     working_directory: ~/go/src/github.com/litmuschaos/chaos-operator
     steps: 
       - attach_workspace:

--- a/buildscripts/push
+++ b/buildscripts/push
@@ -20,6 +20,9 @@ function push_release_image(){
     echo "Pushing ${REPONAME}/${IMGNAME}:${CIRCLE_TAG} ..."
     docker tag ${IMAGEID} ${REPONAME}/${IMGNAME}:${CIRCLE_TAG}
     docker push ${REPONAME}/${IMGNAME}:${CIRCLE_TAG}
+    echo "Pushing ${REPONAME}/${IMGNAME}:latest ..."
+    docker tag ${IMAGEID} ${REPONAME}/${IMGNAME}:latest
+    docker push ${REPONAME}/${IMGNAME}:latest
   fi;
 
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: litmus
       containers:
         - name: chaos-operator
-          image: litmuschaos/chaos-operator:latest
+          image: litmuschaos/chaos-operator:ci
           command:
           - chaos-operator
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Homogenises the image tagging practice across litmuschaos components chaos-operator, chaos-exporter & ansible-runner.  

- Uses `ci` tag for images built on updates to master. Released images use `github release tag` and `latest`. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/litmuschaos/litmus/issues/919

**Special notes for your reviewer**:

- The BDD tests executed on minikube in the CircleCi VM/Docker-Machine make use of the same tag with which it is built : `ci` for their execution with the `imagePullPolicy: ifNotPresent` on the deploy/operator.yaml. 

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests