### PR TITLE
Added operator default ENV for chaos runner/monitor image

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,6 +21,10 @@ spec:
           - chaos-operator
           imagePullPolicy: IfNotPresent
           env:
+            #- name: RUNNER_IMAGE
+            #  value: "litmuschaos/ansible-runner:ci"
+            #- name: MONITOR_IMAGE
+            #  value: "litmuschaos/chaos-exporter:ci"
             - name: WATCH_NAMESPACE
               value: 
             - name: POD_NAME

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -151,7 +151,7 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Get the image for runner and monitor pod from chaosengine spec
-	getImage()
+	getMonitorRunnerImage()
 
 	// Fetch the app details from ChaosEngine instance. Check if app is present
 	// Also check, if the app is annotated for chaos & that the labels are unique
@@ -537,16 +537,20 @@ func checkMonitoring(engineReconcile *reconcileEngine, reqLogger logr.Logger) (r
 	return reconcile.Result{}, nil
 }
 
-//getImage take the runner and monitor image from chaos-operator spec
-func getImage() {
+//getMonitorRunnerImage take the runner and monitor image from chaos-operator spec
+func getMonitorRunnerImage() {
 
 	MonitorImage := os.Getenv("MONITOR_IMAGE")
 	RunnerImage := os.Getenv("RUNNER_IMAGE")
 
-	if engine.Instance.Spec.Components.Monitor.Image == "" {
+	if engine.Instance.Spec.Components.Monitor.Image == "" && MonitorImage == "" {
+		engine.Instance.Spec.Components.Monitor.Image = chaosTypes.DefaultMonitorImage
+	} else if engine.Instance.Spec.Components.Monitor.Image == "" {
 		engine.Instance.Spec.Components.Monitor.Image = MonitorImage
 	}
-	if engine.Instance.Spec.Components.Runner.Image == "" {
+	if engine.Instance.Spec.Components.Runner.Image == "" && RunnerImage == "" {
+		engine.Instance.Spec.Components.Runner.Image = chaosTypes.DefaultRunnerImage
+	} else if engine.Instance.Spec.Components.Runner.Image == "" {
 		engine.Instance.Spec.Components.Runner.Image = RunnerImage
 	}
 }

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -151,7 +151,7 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Get the image for runner and monitor pod from chaosengine spec
-	getMonitorRunnerImage()
+	getChaosMonitorRunnerImage()
 
 	// Fetch the app details from ChaosEngine instance. Check if app is present
 	// Also check, if the app is annotated for chaos & that the labels are unique
@@ -537,20 +537,20 @@ func checkMonitoring(engineReconcile *reconcileEngine, reqLogger logr.Logger) (r
 	return reconcile.Result{}, nil
 }
 
-//getMonitorRunnerImage take the runner and monitor image from chaos-operator spec
-func getMonitorRunnerImage() {
+//getChaosMonitorRunnerImage take the runner and monitor image from chaos-operator spec
+func getChaosMonitorRunnerImage() {
 
-	MonitorImage := os.Getenv("MONITOR_IMAGE")
-	RunnerImage := os.Getenv("RUNNER_IMAGE")
+	ChaosMonitorImage := os.Getenv("CHAOS_MONITOR_IMAGE")
+	ChaosRunnerImage := os.Getenv("CHAOS_RUNNER_IMAGE")
 
-	if engine.Instance.Spec.Components.Monitor.Image == "" && MonitorImage == "" {
-		engine.Instance.Spec.Components.Monitor.Image = chaosTypes.DefaultMonitorImage
+	if engine.Instance.Spec.Components.Monitor.Image == "" && ChaosMonitorImage == "" {
+		engine.Instance.Spec.Components.Monitor.Image = chaosTypes.DefaultChaosMonitorImage
 	} else if engine.Instance.Spec.Components.Monitor.Image == "" {
-		engine.Instance.Spec.Components.Monitor.Image = MonitorImage
+		engine.Instance.Spec.Components.Monitor.Image = ChaosMonitorImage
 	}
-	if engine.Instance.Spec.Components.Runner.Image == "" && RunnerImage == "" {
-		engine.Instance.Spec.Components.Runner.Image = chaosTypes.DefaultRunnerImage
+	if engine.Instance.Spec.Components.Runner.Image == "" && ChaosRunnerImage == "" {
+		engine.Instance.Spec.Components.Runner.Image = chaosTypes.DefaultChaosRunnerImage
 	} else if engine.Instance.Spec.Components.Runner.Image == "" {
-		engine.Instance.Spec.Components.Runner.Image = RunnerImage
+		engine.Instance.Spec.Components.Runner.Image = ChaosRunnerImage
 	}
 }

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -151,7 +151,7 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Get the image for runner and monitor pod from chaosengine spec
-	getChaosMonitorRunnerImage()
+	setChaosResourceImage()
 
 	// Fetch the app details from ChaosEngine instance. Check if app is present
 	// Also check, if the app is annotated for chaos & that the labels are unique
@@ -537,8 +537,8 @@ func checkMonitoring(engineReconcile *reconcileEngine, reqLogger logr.Logger) (r
 	return reconcile.Result{}, nil
 }
 
-//getChaosMonitorRunnerImage take the runner and monitor image from chaos-operator spec
-func getChaosMonitorRunnerImage() {
+//setChaosResourceImage take the runner and monitor image from chaos-operator spec
+func setChaosResourceImage() {
 
 	ChaosMonitorImage := os.Getenv("CHAOS_MONITOR_IMAGE")
 	ChaosRunnerImage := os.Getenv("CHAOS_RUNNER_IMAGE")

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -536,12 +537,16 @@ func checkMonitoring(engineReconcile *reconcileEngine, reqLogger logr.Logger) (r
 	return reconcile.Result{}, nil
 }
 
-//getImage take the runner and monitor image from engine spec
+//getImage take the runner and monitor image from chaos-operator spec
 func getImage() {
+
+	MonitorImage := os.Getenv("MONITOR_IMAGE")
+	RunnerImage := os.Getenv("RUNNER_IMAGE")
+
 	if engine.Instance.Spec.Components.Monitor.Image == "" {
-		engine.Instance.Spec.Components.Monitor.Image = chaosTypes.DefaultMonitorImage
+		engine.Instance.Spec.Components.Monitor.Image = MonitorImage
 	}
 	if engine.Instance.Spec.Components.Runner.Image == "" {
-		engine.Instance.Spec.Components.Runner.Image = chaosTypes.DefaultRunnerImage
+		engine.Instance.Spec.Components.Runner.Image = RunnerImage
 	}
 }

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -48,11 +48,11 @@ var (
 	// Log with default name ie: controller_chaosengine
 	Log = logf.Log.WithName("controller_chaosengine")
 
-	// DefaultMonitorImage contains the default value of monitor resource
-	DefaultMonitorImage = "litmuschaos/chaos-exporter:latest"
+	// DefaultChaosMonitorImage contains the default value of monitor resource
+	DefaultChaosMonitorImage = "litmuschaos/chaos-exporter:latest"
 
-	// DefaultRunnerImage contains the default value of runner resource
-	DefaultRunnerImage = "litmuschaos/ansible-runner:latest"
+	// DefaultChaosRunnerImage contains the default value of runner resource
+	DefaultChaosRunnerImage = "litmuschaos/ansible-runner:latest"
 )
 
 // ApplicationInfo contains the chaos details for target application

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -47,12 +47,6 @@ var (
 
 	// Log with default name ie: controller_chaosengine
 	Log = logf.Log.WithName("controller_chaosengine")
-
-	// DefaultRunnerImage contains the default value of runner resource
-	DefaultRunnerImage = "litmuschaos/ansible-runner:latest"
-
-	// DefaultMonitorImage contains the default value of monitor resource
-	DefaultMonitorImage = "litmuschaos/chaos-exporter:latest"
 )
 
 // ApplicationInfo contains the chaos details for target application

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -47,6 +47,12 @@ var (
 
 	// Log with default name ie: controller_chaosengine
 	Log = logf.Log.WithName("controller_chaosengine")
+
+	// DefaultMonitorImage contains the default value of monitor resource
+	DefaultMonitorImage = "litmuschaos/chaos-exporter:latest"
+
+	// DefaultRunnerImage contains the default value of runner resource
+	DefaultRunnerImage = "litmuschaos/ansible-runner:latest"
 )
 
 // ApplicationInfo contains the chaos details for target application


### PR DESCRIPTION
This PR will help in fetching the  image of chaos-runner pod and monitor pod from chaos-engine  spec and if it is not present in chaos-engine spec then it will take images from chaos-operator envs and in the worst case if images are not present in both chaos-engine spec and chaos-operator envs then it will set default values.
Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests