### PR TITLE
(optimize): Update the total chaos count logic

### DIFF
--- a/pkg/controller/resource/daemonset.go
+++ b/pkg/controller/resource/daemonset.go
@@ -66,7 +66,7 @@ func checkForChaosEnabledDaemonSet(targetAppList *v1.DaemonSetList, ce *chaosTyp
 		annotationValue := daemonSet.ObjectMeta.GetAnnotations()[ChaosAnnotationKey]
 		chaosEnabledDaemonSet = CountTotalChaosEnabled(annotationValue, chaosEnabledDaemonSet)
 		if chaosEnabledDaemonSet > 1 {
-			return ce, chaosEnabledDaemonSet, errors.New("too many chaos candidates with same label, either provide unique labels or annotate only desired app for chaos")
+			return ce, chaosEnabledDaemonSet, errors.New("too many daemonsets with specified label are annotated for chaos, either provide unique labels or annotate only desired app for chaos")
 		}
 	}
 	return ce, chaosEnabledDaemonSet, nil

--- a/pkg/controller/resource/daemonset.go
+++ b/pkg/controller/resource/daemonset.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"errors"
 	"fmt"
 
 	v1 "k8s.io/api/apps/v1"
@@ -32,12 +33,13 @@ func CheckDaemonSetAnnotation(clientSet *kubernetes.Clientset, ce *chaosTypes.En
 	if err != nil {
 		return ce, err
 	}
-	ce, chaosEnabledDaemonSet := checkForEnabledChaos(targetAppList, ce)
-	err = ValidateTotalChaosEnabled(chaosEnabledDaemonSet)
+	ce, chaosEnabledDaemonSet, err := checkForChaosEnabledDaemonSet(targetAppList, ce)
 	if err != nil {
 		return ce, err
 	}
-	chaosTypes.Log.Info("DaemonSet chaos candidate:", "appName: ", ce.AppName, " appUUID: ", ce.AppUUID)
+	if chaosEnabledDaemonSet == 0 {
+		return ce, errors.New("no chaos-candidate found")
+	}
 	return ce, nil
 }
 
@@ -56,13 +58,16 @@ func getDaemonSetLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInf
 }
 
 // This will check and count the total chaos enabled application
-func checkForEnabledChaos(targetAppList *v1.DaemonSetList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int) {
+func checkForChaosEnabledDaemonSet(targetAppList *v1.DaemonSetList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledDaemonSet := 0
 	for _, daemonSet := range targetAppList.Items {
 		ce.AppName = daemonSet.ObjectMeta.Name
 		ce.AppUUID = daemonSet.ObjectMeta.UID
 		annotationValue := daemonSet.ObjectMeta.GetAnnotations()[ChaosAnnotationKey]
 		chaosEnabledDaemonSet = CountTotalChaosEnabled(annotationValue, chaosEnabledDaemonSet)
+		if chaosEnabledDaemonSet > 1 {
+			return ce, chaosEnabledDaemonSet, errors.New("too many chaos candidates with same label, either provide unique labels or annotate only desired app for chaos")
+		}
 	}
-	return ce, chaosEnabledDaemonSet
+	return ce, chaosEnabledDaemonSet, nil
 }

--- a/pkg/controller/resource/deployment.go
+++ b/pkg/controller/resource/deployment.go
@@ -67,7 +67,7 @@ func checkForChaosEnabledDeployment(targetAppList *v1.DeploymentList, ce *chaosT
 		annotationValue := deployment.ObjectMeta.GetAnnotations()[ChaosAnnotationKey]
 		chaosEnabledDeployment = CountTotalChaosEnabled(annotationValue, chaosEnabledDeployment)
 		if chaosEnabledDeployment > 1 {
-			return ce, chaosEnabledDeployment, errors.New("too many chaos candidates with same label, either provide unique labels or annotate only desired app for chaos")
+			return ce, chaosEnabledDeployment, errors.New("too many deployments with specified label are annotated for chaos, either provide unique labels or annotate only desired app for chaos")
 		}
 	}
 	return ce, chaosEnabledDeployment, nil

--- a/pkg/controller/resource/resource.go
+++ b/pkg/controller/resource/resource.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resource
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -58,6 +57,7 @@ func CheckChaosAnnotation(ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, er
 	default:
 		return ce, fmt.Errorf("resource type '%s' not supported for induce chaos", ce.AppInfo.Kind)
 	}
+	chaosTypes.Log.Info("chaos candidate of", "kind:", ce.AppInfo.Kind ,"appName: ", ce.AppName, "appUUID: ", ce.AppUUID)
 	return ce, nil
 }
 
@@ -67,14 +67,4 @@ func CountTotalChaosEnabled(annotationValue string, chaosCandidates int) int {
 		chaosCandidates++
 	}
 	return chaosCandidates
-}
-
-// ValidateTotalChaosEnabled will validate the total chaos count
-func ValidateTotalChaosEnabled(chaosCandidates int) error {
-	if chaosCandidates > 1 {
-		return errors.New("too many chaos candidates with same label, either provide unique labels or annotate only desired app for chaos")
-	} else if chaosCandidates == 0 {
-		return errors.New("no chaos-candidate found")
-	}
-	return nil
 }

--- a/pkg/controller/resource/statefulset.go
+++ b/pkg/controller/resource/statefulset.go
@@ -67,7 +67,7 @@ func checkForChaosEnabledStatefulSet(targetAppList *v1.StatefulSetList, ce *chao
 		annotationValue := statefulSet.ObjectMeta.GetAnnotations()[ChaosAnnotationKey]
 		chaosEnabledStatefulSet = CountTotalChaosEnabled(annotationValue, chaosEnabledStatefulSet)
 		if chaosEnabledStatefulSet > 1 {
-			return ce, chaosEnabledStatefulSet, errors.New("too many chaos candidates with same label, either provide unique labels or annotate only desired app for chaos")
+			return ce, chaosEnabledStatefulSet, errors.New("too many statefulsets with specified label are annotated for chaos, either provide unique labels or annotate only desired app for chaos")
 		}
 	}
 	return ce, chaosEnabledStatefulSet, nil

--- a/pkg/controller/resource/statefulset.go
+++ b/pkg/controller/resource/statefulset.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"errors"
 	"fmt"
 
 	v1 "k8s.io/api/apps/v1"
@@ -32,16 +33,12 @@ func CheckStatefulSetAnnotation(clientSet *kubernetes.Clientset, ce *chaosTypes.
 	if err != nil {
 		return ce, err
 	}
-	chaosEnabledStatefulset := 0
-	for _, statefulset := range targetAppList.Items {
-		ce.AppName = statefulset.ObjectMeta.Name
-		ce.AppUUID = statefulset.ObjectMeta.UID
-		annotationValue := statefulset.ObjectMeta.GetAnnotations()[ChaosAnnotationKey]
-		chaosEnabledStatefulset = CountTotalChaosEnabled(annotationValue, chaosEnabledStatefulset)
-	}
-	err = ValidateTotalChaosEnabled(chaosEnabledStatefulset)
+	ce, chaosEnabledStatefulSet, err := checkForChaosEnabledStatefulSet(targetAppList, ce)
 	if err != nil {
 		return ce, err
+	}
+	if chaosEnabledStatefulSet == 0 {
+		return ce, errors.New("no chaos-candidate found")
 	}
 	chaosTypes.Log.Info("Statefulset chaos candidate:", "appName: ", ce.AppName, " appUUID: ", ce.AppUUID)
 	return ce, nil
@@ -59,4 +56,19 @@ func getStatefulSetLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineI
 		return nil, fmt.Errorf("no statefulset apps with matching labels %s", ce.Instance.Spec.Appinfo.Applabel)
 	}
 	return targetAppList, err
+}
+
+// This will check and count the total chaos enabled application
+func checkForChaosEnabledStatefulSet(targetAppList *v1.StatefulSetList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
+	chaosEnabledStatefulSet := 0
+	for _, statefulSet := range targetAppList.Items {
+		ce.AppName = statefulSet.ObjectMeta.Name
+		ce.AppUUID = statefulSet.ObjectMeta.UID
+		annotationValue := statefulSet.ObjectMeta.GetAnnotations()[ChaosAnnotationKey]
+		chaosEnabledStatefulSet = CountTotalChaosEnabled(annotationValue, chaosEnabledStatefulSet)
+		if chaosEnabledStatefulSet > 1 {
+			return ce, chaosEnabledStatefulSet, errors.New("too many chaos candidates with same label, either provide unique labels or annotate only desired app for chaos")
+		}
+	}
+	return ce, chaosEnabledStatefulSet, nil
 }


### PR DESCRIPTION
Signed-off-by: chandan kumar <chandan.kr404@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Optimize the total chaos count logic
    - **Explanation**: If the `5` application have the same label then for loop will run only once and if he got the chaos count greater than `1` then the loop will break with the error `too many chaos counts`
  
- Refactor the function `CheckDeploymentAnnotation`, `CheckDaemonSetAnnotation` and `CheckStatefulSetAnnotation` according to BCH rule

**Which issue this PR fixes**: #92 

**Checklist:**
- [x] Fixes #92 
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [x] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests