### PR TITLE
(feat)GoExecutor: Added support to run experiment via GoExecutor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
 # docker info
-DOCKER_REPO ?= rahulchheda1997
+DOCKER_REPO ?= litmuschaos
 DOCKER_IMAGE ?= chaos-operator
 DOCKER_TAG ?= latest
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
 # docker info
-DOCKER_REPO ?= litmuschaos
+DOCKER_REPO ?= rahulchheda1997
 DOCKER_IMAGE ?= chaos-operator
 DOCKER_TAG ?= latest
 

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -76,6 +76,8 @@ type MonitorInfo struct {
 type RunnerInfo struct {
 	//Image of the runner pod
 	Image string `json:"image"`
+	//Type of Executor
+	Type string `json:"type,omitempty"`
 }
 
 // ExperimentList defines information about chaos experiments defined in the chaos engine

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -75,7 +75,7 @@ type MonitorInfo struct {
 // RunnerInfo defines the information of the runnerinfo pod
 type RunnerInfo struct {
 	//Image of the runner pod
-	Image string `json:"image"`
+	Image string `json:"image,omitempty"`
 	//Type of Executor
 	Type string `json:"type,omitempty"`
 }

--- a/pkg/apis/litmuschaos/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/litmuschaos/v1alpha1/zz_generated.deepcopy.go
@@ -56,7 +56,7 @@ func (in *ChaosEngine) DeepCopyObject() runtime.Object {
 func (in *ChaosEngineList) DeepCopyInto(out *ChaosEngineList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]ChaosEngine, len(*in))
@@ -165,7 +165,7 @@ func (in *ChaosExperiment) DeepCopyObject() runtime.Object {
 func (in *ChaosExperimentList) DeepCopyInto(out *ChaosExperimentList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]ChaosExperiment, len(*in))
@@ -259,7 +259,7 @@ func (in *ChaosResult) DeepCopyObject() runtime.Object {
 func (in *ChaosResultList) DeepCopyInto(out *ChaosResultList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]ChaosResult, len(*in))

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	LitmuschaosV1alpha1() litmuschaosv1alpha1.LitmuschaosV1alpha1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Litmuschaos() litmuschaosv1alpha1.LitmuschaosV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // LitmuschaosV1alpha1 retrieves the LitmuschaosV1alpha1Client
 func (c *Clientset) LitmuschaosV1alpha1() litmuschaosv1alpha1.LitmuschaosV1alpha1Interface {
-	return c.litmuschaosV1alpha1
-}
-
-// Deprecated: Litmuschaos retrieves the default version of LitmuschaosClient.
-// Please explicitly pick a version.
-func (c *Clientset) Litmuschaos() litmuschaosv1alpha1.LitmuschaosV1alpha1Interface {
 	return c.litmuschaosV1alpha1
 }
 

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -41,7 +41,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	cs := &Clientset{}
+	cs := &Clientset{tracker: o}
 	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
@@ -63,20 +63,20 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 type Clientset struct {
 	testing.Fake
 	discovery *fakediscovery.FakeDiscovery
+	tracker   testing.ObjectTracker
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 	return c.discovery
 }
 
+func (c *Clientset) Tracker() testing.ObjectTracker {
+	return c.tracker
+}
+
 var _ clientset.Interface = &Clientset{}
 
 // LitmuschaosV1alpha1 retrieves the LitmuschaosV1alpha1Client
 func (c *Clientset) LitmuschaosV1alpha1() litmuschaosv1alpha1.LitmuschaosV1alpha1Interface {
-	return &fakelitmuschaosv1alpha1.FakeLitmuschaosV1alpha1{Fake: &c.Fake}
-}
-
-// Litmuschaos retrieves the LitmuschaosV1alpha1Client
-func (c *Clientset) Litmuschaos() litmuschaosv1alpha1.LitmuschaosV1alpha1Interface {
 	return &fakelitmuschaosv1alpha1.FakeLitmuschaosV1alpha1{Fake: &c.Fake}
 }

--- a/pkg/client/clientset/versioned/typed/litmuschaos/v1alpha1/litmuschaos_client.go
+++ b/pkg/client/clientset/versioned/typed/litmuschaos/v1alpha1/litmuschaos_client.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 	"github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/scheme"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -81,7 +80,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Added support for litmuschaos/chaos-executor:ci (image)
New ChaosEngine spec for invoking the go-Executor 
```
chaos:~$ cat chaosEngine.yaml 
# chaosengine.yaml
apiVersion: litmuschaos.io/v1alpha1
kind: ChaosEngine
metadata:
  name: engine-nginx
  namespace: dance
spec:
  jobCleanUpPolicy: retain
  monitoring: false
  components:
    runner:
      image: "litmuschaos/chaos-executor:ci"
      type: "go"
  appinfo: 
    appns: dance 
    # FYI, To see app label, apply kubectl get pods --show-labels
    applabel: "app=nginx" 
    appkind: deployment
  chaosServiceAccount: nginx 
  experiments:
    - name: pod-delete
      spec:
        components:
        - name: TARGET_CONTAINER
          value: nginx

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests