### PR TITLE
(enhancement)crds: add openapi specification based schema validation for chaos CRDs

### DIFF
--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -11,7 +11,6 @@ spec:
     singular: chaosengine
   scope: Namespaced
   subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -11,6 +11,7 @@ spec:
     singular: chaosengine
   scope: Namespaced
   subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -28,6 +29,63 @@ spec:
           type: object
         spec:
           type: object
+          properties:
+            monitoring: 
+              type: boolean
+            jobCleanUpPolicy: 
+              type: string
+              pattern: ^(delete|retain)$
+              # alternate ways to do this in case of complex pattern matches
+              #oneOf:
+              #  - pattern: '^delete$'
+              #  - pattern: '^retain$'
+            appinfo:
+              type: object
+              properties:
+                appkind: 
+                  type: string
+                  pattern: ^(deployment|statefulset|daemonset)$
+                applabel: 
+                  type: string
+                appns: 
+                  type: string
+            chaosServiceAccount:
+              type: string
+            components:
+              type: object
+              properties: 
+                monitor: 
+                  type: object
+                  properties: 
+                    image: 
+                      type: string
+                runner: 
+                  type: object
+                  properties:
+                    image: 
+                      type: string
+                    type:
+                      type: string
+                      pattern: ^(go|ansible)$
+            experiments:
+              type: array
+              items:
+                type: object
+                properties:
+                  name: 
+                    type: string
+                  spec:
+                    type: object
+                    properties:
+                      components: 
+                        type: array
+                        items:
+                          type: object
+                          properties:  
+                            name: 
+                              type: string
+                            value: 
+                              type: string 
         status:
           type: object
   version: v1alpha1

--- a/deploy/crds/chaosexperiment_crd.yaml
+++ b/deploy/crds/chaosexperiment_crd.yaml
@@ -29,6 +29,75 @@ spec:
           type: object
         spec:
           type: object
+          properties:
+            definition: 
+              type: object
+              properties:
+                args: 
+                  type: array
+                  items: 
+                    type: string
+                command: 
+                  type: array
+                  items: 
+                    type: string
+                env:
+                  type: array
+                  items:
+                    type: object
+                    properties: 
+                      name: 
+                        type: string
+                      value: 
+                        type: string 
+                image: 
+                  type: string
+                labels:
+                  type: object
+                  properties: 
+                    name: 
+                      type: string
+                permissions: 
+                  type: object
+                  properties: 
+                    apiGroups: 
+                      type: array
+                      items: 
+                        type: string
+                    resources: 
+                      type: array
+                      items: 
+                        type: string
+                    verbs: 
+                      type: array
+                      items: 
+                        type: string
+                configmaps: 
+                  type: array
+                  items: 
+                    type: object
+                    properties:
+                      name: 
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                      mountPath: 
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                secrets: 
+                  type: array
+                  items: 
+                    type: object
+                    properties:
+                      name: 
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                      mountPath: 
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
         status:
           type: object
   version: v1alpha1
@@ -36,3 +105,4 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- The chaosExperiment & chaosEngine CRDs are dev/user facing custom resources in LitmusChaos. These determine the execution and outcome of the chaos experiment & thus need validation at a pre-deployment level to prevent unnecessary runtime failures

- The chaos-executor (esp. the ansible executor) today has complex validation logic that is not needed provided the CRD schema is strictly enforced. One way to achieving this is with the OpenAPI specification based schema validation.  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/litmuschaos/litmus/issues/1002

**Special notes for your reviewer**:

- ~~This is a WIP PR with validation adding for chaosExperiment CRDs without specifying the "pruning" functionality of the OpenAPI to drop unspecified fields.~~ 

- ~~Support for configmap/secret validation and validation spec for chaosEngine schema is being added in subsequent commits.~~

- The support for ChaosEngine CRD validation with pattern matching for spec components as well as configmap/secret volume support for chaosexpriments (with support to detect malformed spec, i.e., empty params) has been added. 

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests