### PR TITLE
(feat): Add chaosType [app/infra] in engine spec

### DIFF
--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -27,6 +27,8 @@ import (
 type ChaosEngineSpec struct {
 	//Appinfo contains deployment details of AUT
 	Appinfo ApplicationParams `json:"appinfo"`
+	//ChaosType define wheather it is an infra chaos or app chaos
+	ChaosType string `json:"chaosType,omitempty"`
 	//ChaosServiceAccount is the SvcAcc specified for chaos runner pods
 	ChaosServiceAccount string `json:"chaosServiceAccount"`
 	//Components contains the image of runnner and monitor pod

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -153,6 +153,12 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 	// Get the image for runner and monitor pod from chaosengine spec,operator env or default values.
 	setChaosResourceImage()
 
+	//getChaosType fetch the chaosType from engine spec
+	err = getChaosType()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Fetch the app details from ChaosEngine instance. Check if app is present
 	// Also check, if the app is annotated for chaos & that the labels are unique
 	engine, err := getApplicationDetail(engine)
@@ -160,11 +166,13 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	// Determine whether apps with matching labels have chaos annotation set to true
-	engine, err = resource.CheckChaosAnnotation(engine)
-	if err != nil {
-		chaosTypes.Log.Info("Annotation check failed with error: ", err)
-		return reconcile.Result{}, nil
+	if engine.Instance.Spec.ChaosType == "app" {
+		// Determine whether apps with matching labels have chaos annotation set to true
+		engine, err = resource.CheckChaosAnnotation(engine)
+		if err != nil {
+			chaosTypes.Log.Info("Annotation check failed with error: ", err)
+			return reconcile.Result{}, nil
+		}
 	}
 	// Define an engineRunner pod which is secondary-resource #1
 	engineRunner, err := newRunnerPodForCR(*engine)
@@ -314,10 +322,10 @@ func getMonitoringENV() []corev1.ServicePort {
 	}
 }
 
-// newRunnerPodForCR defines secondary resource #1 in same namespace as CR */
+// newRunnerPodForCR defines secondary resource #1 in same namespace as CR
 func newRunnerPodForCR(ce chaosTypes.EngineInfo) (*corev1.Pod, error) {
-	if len(ce.AppExperiments) == 0 || ce.AppUUID == "" {
-		return nil, errors.New("expected aExList not found")
+	if (len(ce.AppExperiments) == 0 || ce.AppUUID == "") && ce.Instance.Spec.ChaosType == "app" {
+		return nil, errors.New("Application experiment list or UUID is empty")
 	}
 	var podObj *corev1.Pod
 	var err error
@@ -540,6 +548,7 @@ func getApplicationDetail(ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, er
 	chaosTypes.Log.Info("Monitoring Status derived from chaosengine is", "monitoringStatus", ce.Instance.Spec.Monitoring)
 	chaosTypes.Log.Info("Runner image derived from chaosengine is", "runnerImage", ce.Instance.Spec.Components.Runner.Image)
 	chaosTypes.Log.Info("exporter image derived from chaosengine is", "exporterImage", ce.Instance.Spec.Components.Monitor.Image)
+	chaosTypes.Log.Info("chaos type is ", "chaostype", ce.Instance.Spec.ChaosType)
 	return ce, nil
 }
 
@@ -595,4 +604,16 @@ func setChaosResourceImage() {
 	} else if engine.Instance.Spec.Components.Runner.Image == "" {
 		engine.Instance.Spec.Components.Runner.Image = ChaosRunnerImage
 	}
+}
+
+func getChaosType() error {
+
+	if engine.Instance.Spec.ChaosType == "" {
+		engine.Instance.Spec.ChaosType = chaosTypes.DefaultChaosType
+
+	}
+	if engine.Instance.Spec.ChaosType != "app" && engine.Instance.Spec.ChaosType != "infra" {
+		return fmt.Errorf("chaos type '%s', is not supported it should be app or infra", engine.Instance.Spec.ChaosType)
+	}
+	return nil
 }

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -42,6 +42,9 @@ var (
 	// AppLabelKey contains the application label key
 	AppLabelKey string
 
+	// DefaultChaosType contains the type of chaos - infra/app
+	DefaultChaosType = "app"
+
 	// AppLabelValue contains the application label value
 	AppLabelValue string
 


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

-  Added chaosType in engine spec - infra/app

-  Skip the annotation check for infra chaos

**engine yaml after changes**

```
# chaosengine.yaml
apiVersion: litmuschaos.io/v1alpha1
kind: ChaosEngine
metadata:
  name: engine-nginx
  namespace: default
spec:
  jobCleanUpPolicy: retain
 chaosType: "infra" # app/infra      <--- Add chaosType here
  monitoring: false
  appinfo: 
    appns: default 
    # FYI, To see app label, apply kubectl get pods --show-labels
    applabel: "run=myserver" 
    appkind: deployment
  chaosServiceAccount: nginx 
  experiments:
    - name: container-kill
      spec:
        components:
        - name: TARGET_CONTAINER
          value: nginx
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1012

**Special notes for your reviewer**:

**Checklist:**
- [x] Fixes #1012
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests