### PR TITLE
(feat): Add auxiliaryAppInfo (details of dependent apps in infra chao…

### DIFF
--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -37,6 +37,8 @@ type ChaosEngineSpec struct {
 	Monitoring bool `json:"monitoring,omitempty"`
 	//JobCleanUpPolicy decides to retain or delete the jobs
 	JobCleanUpPolicy string `json:"jobCleanUpPolicy,omitempty"`
+	//AuxiliaryAppInfo contains details of dependent applications (infra chaos)
+	AuxiliaryAppInfo string `json:"auxiliaryAppInfo,omitempty"`
 }
 
 // ChaosEngineStatus defines the observed state of ChaosEngine

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -283,6 +283,10 @@ func getChaosRunnerENV(cr *litmuschaosv1alpha1.ChaosEngine, aExList []string) []
 			Name:  "CHAOS_SVC_ACC",
 			Value: cr.Spec.ChaosServiceAccount,
 		},
+		{
+			Name:  "AUXILIARY_APPINFO",
+			Value: cr.Spec.AuxiliaryAppInfo,
+		},
 	}
 }
 

--- a/pkg/controller/chaosengine/chaosengine_controller_test.go
+++ b/pkg/controller/chaosengine/chaosengine_controller_test.go
@@ -327,6 +327,7 @@ func TestGetChaosRunnerENV(t *testing.T) {
 	fakeServiceAcc := "Fake Service Account"
 	fakeAppLabel := "Fake Label"
 	fakeAExList := []string{"fake string"}
+	fakeAuxilaryAppInfo := "ns1:name=percona,ns2:run=nginx"
 
 	tests := map[string]struct {
 		instance       *litmuschaosv1alpha1.ChaosEngine
@@ -345,6 +346,7 @@ func TestGetChaosRunnerENV(t *testing.T) {
 						Applabel: fakeAppLabel,
 						Appns:    fakeNameSpace,
 					},
+					AuxiliaryAppInfo: fakeAuxilaryAppInfo,
 				},
 			},
 			aExList: fakeAExList,
@@ -369,6 +371,10 @@ func TestGetChaosRunnerENV(t *testing.T) {
 					Name:  "CHAOS_SVC_ACC",
 					Value: fakeServiceAcc,
 				},
+				{
+					Name:  "AUXILIARY_APPINFO",
+					Value: fakeAuxilaryAppInfo,
+				},
 			},
 		},
 	}
@@ -376,8 +382,8 @@ func TestGetChaosRunnerENV(t *testing.T) {
 		name, mock := name, mock
 		t.Run(name, func(t *testing.T) {
 			actualResult := getChaosRunnerENV(mock.instance, mock.aExList)
-			if len(actualResult) != 5 {
-				t.Fatalf("Test %q failed: expected array length to be 5", name)
+			if len(actualResult) != 6 {
+				t.Fatalf("Test %q failed: expected array length to be 6", name)
 			}
 			for index, result := range actualResult {
 				if result.Value != mock.expectedResult[index].Value {


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

-  Added auxiliaryAppInfo variable inside engine spec

- AuxiliaryAppInfo contains the details (labels and ns) of dependent applications in case of infra chaos

```
# chaosengine.yaml
apiVersion: litmuschaos.io/v1alpha1
kind: ChaosEngine
metadata:
  name: engine-nginx
  namespace: default
spec:
  jobCleanUpPolicy: retain
 auxilaryAppInfo: "ns1:app=percona,ns2:run=nginx"      <--- Add details of dependent apps here
  monitoring: false
  appinfo: 
    appns: default 
    # FYI, To see app label, apply kubectl get pods --show-labels
    applabel: "run=myserver" 
    appkind: deployment
  chaosServiceAccount: nginx 
  experiments:
    - name: container-kill
      spec:
        components:
        - name: TARGET_CONTAINER
          value: nginx
```

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests