### PR TITLE
(refactor): Refactor according to the BCH rule 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/_output
 *.swp
 *.orig
+.idea/

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -48,40 +49,33 @@ import (
 var (
 	metricsHost       = "0.0.0.0"
 	metricsPort int32 = 8383
+	log               = logf.Log.WithName("cmd")
 )
-var log = logf.Log.WithName("cmd")
-
-func printVersion() {
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
-}
-
-func registerComponents(cfg *rest.Config, namespace string) (manager.Manager, error) {
-
-	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace, MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort)})
-	if err != nil {
-		return mgr, err
-	}
-
-	log.Info("Registering Components.")
-
-	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		return mgr, err
-	}
-
-	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
-		return mgr, err
-	}
-
-	return mgr, err
-}
 
 func main() {
+	// initializing the log configuration
+	initializingLogConfiguration()
 
+	// printing the operator and go configuration
+	printVersion()
+
+	// setting up initial configuration of chaos-operator
+	mgr, err := initialConfiguration()
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Start the Chaos-Operator
+	log.Info("Starting the Chaos-Operator...")
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Error(err, "Chaos-Operator exited non-zero")
+		os.Exit(1)
+	}
+}
+
+// initialize the log configuration
+func initializingLogConfiguration() {
 	// Add the zap logger flag set to the CLI. The flag set must
 	// be added before calling pflag.Parse().
 	pflag.CommandLine.AddFlagSet(zap.FlagSet())
@@ -101,60 +95,88 @@ func main() {
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
 	logf.SetLogger(zap.Logger())
+}
 
-	printVersion()
+func printVersion() {
+	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+}
 
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
-		os.Exit(1)
+// initializing the configuration of chaos-operator
+func initialConfiguration() (manager.Manager, error) {
+	//setting up leader and analytics
+	if err := initializingLeaderAndAnalytics(); err != nil {
+		return nil, err
 	}
 
-	// Get a config to talk to the apiserver
-	cfg, err := config.GetConfig()
+	// creating metrics service
+	cfg, namespace, err := initializeMetricsService()
 	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
+		return nil, err
 	}
 
-	ctx := context.TODO()
+	// registering the components of chaos-operator
+	mgr, err := registerComponents(cfg, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return mgr, nil
+}
 
+func initializingLeaderAndAnalytics() error {
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "chaos-operator-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
+	if err := leader.Become(context.TODO(), "chaos-operator-lock"); err != nil {
+		return err
 	}
 
-	isAnalytics := strings.ToUpper(os.Getenv("ANALYTICS"))
-	// Check if the TrackingStatus env has been negated or not
-	if isAnalytics != "FALSE" {
-		err := analytics.TriggerAnalytics()
-		if err != nil {
+	// Trigger the Analytics if it's enabled
+	if isAnalytics := strings.ToUpper(os.Getenv("ANALYTICS")); isAnalytics != "FALSE" {
+		if err := analytics.TriggerAnalytics(); err != nil {
 			log.Error(err, "")
 		}
 	}
 
-	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := registerComponents(cfg, namespace)
+	return nil
+}
+
+func initializeMetricsService() (*rest.Config, string, error) {
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
+		return cfg, "", err
 	}
+
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get watch namespace %v", err)
+	}
+
 	// Create Service object to expose the metrics port(s).
-	servicePorts := []v1.ServicePort{
-		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-	}
-	_, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
-	if err != nil {
+	servicePorts := []v1.ServicePort{{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}}}
+	if _, err := metrics.CreateMetricsService(context.TODO(), cfg, servicePorts); err != nil {
 		log.Info("Could not create metrics Service", "error", err.Error())
 	}
+	return cfg, namespace, nil
+}
 
-	log.Info("Starting the Chaos-Operator...")
+func registerComponents(cfg *rest.Config, namespace string) (manager.Manager, error) {
 
-	// Start the Chaos-Operator
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		log.Error(err, "Manager exited non-zero")
-		os.Exit(1)
+	// Create a new Cmd to provide shared dependencies and start components
+	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace, MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort)})
+	if err != nil {
+		return mgr, err
 	}
+
+	// Setup Scheme for all resources
+	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		return nil, err
+	}
+
+	// Setup all Controllers
+	if err := controller.AddToManager(mgr); err != nil {
+		return nil, err
+	}
+
+	return mgr, nil
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -25,9 +25,6 @@ import (
 	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	"github.com/litmuschaos/chaos-operator/pkg/analytics"
-	"github.com/litmuschaos/chaos-operator/pkg/apis"
-	"github.com/litmuschaos/chaos-operator/pkg/controller"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -36,13 +33,16 @@ import (
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	"github.com/litmuschaos/chaos-operator/pkg/analytics"
+	"github.com/litmuschaos/chaos-operator/pkg/apis"
+	"github.com/litmuschaos/chaos-operator/pkg/controller"
 )
 
 // Change below variables to serve metrics on different host or port.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -82,7 +82,6 @@ func registerComponents(cfg *rest.Config, namespace string) (manager.Manager, er
 
 func main() {
 
-	log.Info("-----------NEW RUN--------")
 	// Add the zap logger flag set to the CLI. The flag set must
 	// be added before calling pflag.Parse().
 	pflag.CommandLine.AddFlagSet(zap.FlagSet())
@@ -151,9 +150,9 @@ func main() {
 		log.Info("Could not create metrics Service", "error", err.Error())
 	}
 
-	log.Info("Starting the Cmd.")
+	log.Info("Starting the Chaos-Operator...")
 
-	// Start the Cmd
+	// Start the Chaos-Operator
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		log.Error(err, "Manager exited non-zero")
 		os.Exit(1)

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -171,7 +171,7 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 		// Determine whether apps with matching labels have chaos annotation set to true
 		engine, err = resource.CheckChaosAnnotation(engine)
 		if err != nil {
-			chaosTypes.Log.Info("Annotation check failed with error: ", err)
+			chaosTypes.Log.Info("Annotation check failed with", "error:", err)
 			return reconcile.Result{}, nil
 		}
 	}
@@ -302,9 +302,9 @@ func getChaosRunnerENV(cr *litmuschaosv1alpha1.ChaosEngine, aExList []string, Cl
 // getChaosMonitorENV return the env required for chaos-Monitor
 func getChaosMonitorENV(cr *litmuschaosv1alpha1.ChaosEngine, aUUID types.UID) []corev1.EnvVar {
 	return []corev1.EnvVar{
-		{ Name:  "CHAOSENGINE", Value: cr.Name },
-		{ Name:  "APP_UUID", Value: string(aUUID) },
-		{ Name:  "APP_NAMESPACE", Value: cr.Spec.Appinfo.Appns },
+		{Name: "CHAOSENGINE", Value: cr.Name},
+		{Name: "APP_UUID", Value: string(aUUID)},
+		{Name: "APP_NAMESPACE", Value: cr.Spec.Appinfo.Appns},
 	}
 }
 
@@ -332,8 +332,7 @@ func newGoRunnerPodForCR(ce chaosTypes.EngineInfo) (*corev1.Pod, error) {
 				WithEnvsNew(getChaosRunnerENV(ce.Instance, ce.AppExperiments, analytics.ClientUUID)).
 				WithName("chaos-runner").
 				WithImage(ce.Instance.Spec.Components.Runner.Image).
-				WithImagePullPolicy(corev1.PullIfNotPresent),
-		).Build()
+				WithImagePullPolicy(corev1.PullIfNotPresent)).Build()
 }
 
 func newAnsibleRunnerPodForCR(ce chaosTypes.EngineInfo) (*corev1.Pod, error) {
@@ -350,8 +349,7 @@ func newAnsibleRunnerPodForCR(ce chaosTypes.EngineInfo) (*corev1.Pod, error) {
 				WithImagePullPolicy(corev1.PullIfNotPresent).
 				WithCommandNew([]string{"/bin/bash"}).
 				WithArgumentsNew([]string{"-c", "ansible-playbook ./executor/test.yml -i /etc/ansible/hosts; exit 0"}).
-				WithEnvsNew(getChaosRunnerENV(ce.Instance, ce.AppExperiments, analytics.ClientUUID)),
-		).Build()
+				WithEnvsNew(getChaosRunnerENV(ce.Instance, ce.AppExperiments, analytics.ClientUUID))).Build()
 }
 
 // newMonitorPodForCR defines secondary resource #2 in same namespace as CR */
@@ -374,8 +372,7 @@ func newMonitorPodForCR(engine chaosTypes.EngineInfo) (*corev1.Pod, error) {
 				WithName("chaos-monitor").
 				WithImage(engine.Instance.Spec.Components.Monitor.Image).
 				WithPortsNew([]corev1.ContainerPort{{ContainerPort: 8080, Protocol: "TCP", Name: "metrics"}}).
-				WithEnvsNew(getChaosMonitorENV(engine.Instance, engine.AppUUID)),
-		).Build()
+				WithEnvsNew(getChaosMonitorENV(engine.Instance, engine.AppUUID))).Build()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/resource/daemonset.go
+++ b/pkg/controller/resource/daemonset.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	v1 "k8s.io/api/apps/v1"
+	appsV1 "k8s.io/api/apps/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -44,7 +44,7 @@ func CheckDaemonSetAnnotation(clientSet *kubernetes.Clientset, ce *chaosTypes.En
 }
 
 // getDaemonSetLists will list the daemonSets which having the chaos label
-func getDaemonSetLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInfo) (*v1.DaemonSetList, error) {
+func getDaemonSetLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInfo) (*appsV1.DaemonSetList, error) {
 	targetAppList, err := clientSet.AppsV1().DaemonSets(ce.AppInfo.Namespace).List(metaV1.ListOptions{
 		LabelSelector: ce.Instance.Spec.Appinfo.Applabel,
 		FieldSelector: ""})
@@ -58,7 +58,7 @@ func getDaemonSetLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInf
 }
 
 // This will check and count the total chaos enabled application
-func checkForChaosEnabledDaemonSet(targetAppList *v1.DaemonSetList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
+func checkForChaosEnabledDaemonSet(targetAppList *appsV1.DaemonSetList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledDaemonSet := 0
 	for _, daemonSet := range targetAppList.Items {
 		ce.AppName = daemonSet.ObjectMeta.Name

--- a/pkg/controller/resource/deployment.go
+++ b/pkg/controller/resource/deployment.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"fmt"
 
+	v1 "k8s.io/api/apps/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	appsV1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
 
 	chaosTypes "github.com/litmuschaos/chaos-operator/pkg/controller/types"
@@ -45,7 +45,7 @@ func CheckDeploymentAnnotation(clientSet *kubernetes.Clientset, ce *chaosTypes.E
 }
 
 // getDeploymentLists will list the deployments which having the chaos label
-func getDeploymentLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInfo) (*appsV1.DeploymentList, error) {
+func getDeploymentLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInfo) (*v1.DeploymentList, error) {
 	targetAppList, err := clientSet.AppsV1().Deployments(ce.AppInfo.Namespace).List(metaV1.ListOptions{
 		LabelSelector: ce.Instance.Spec.Appinfo.Applabel,
 		FieldSelector: ""})
@@ -59,7 +59,7 @@ func getDeploymentLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineIn
 }
 
 // This will check and count the total chaos enabled application
-func checkForChaosEnabledDeployment(targetAppList *appsV1.DeploymentList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
+func checkForChaosEnabledDeployment(targetAppList *v1.DeploymentList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledDeployment := 0
 	for _, deployment := range targetAppList.Items {
 		ce.AppName = deployment.ObjectMeta.Name

--- a/pkg/controller/resource/deployment.go
+++ b/pkg/controller/resource/deployment.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"fmt"
 
-	v1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsV1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
 
 	chaosTypes "github.com/litmuschaos/chaos-operator/pkg/controller/types"
@@ -45,8 +45,8 @@ func CheckDeploymentAnnotation(clientSet *kubernetes.Clientset, ce *chaosTypes.E
 }
 
 // getDeploymentLists will list the deployments which having the chaos label
-func getDeploymentLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInfo) (*v1.DeploymentList, error) {
-	targetAppList, err := clientSet.AppsV1().Deployments(ce.AppInfo.Namespace).List(metav1.ListOptions{
+func getDeploymentLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInfo) (*appsV1.DeploymentList, error) {
+	targetAppList, err := clientSet.AppsV1().Deployments(ce.AppInfo.Namespace).List(metaV1.ListOptions{
 		LabelSelector: ce.Instance.Spec.Appinfo.Applabel,
 		FieldSelector: ""})
 	if err != nil {
@@ -59,7 +59,7 @@ func getDeploymentLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineIn
 }
 
 // This will check and count the total chaos enabled application
-func checkForChaosEnabledDeployment(targetAppList *v1.DeploymentList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
+func checkForChaosEnabledDeployment(targetAppList *appsV1.DeploymentList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledDeployment := 0
 	for _, deployment := range targetAppList.Items {
 		ce.AppName = deployment.ObjectMeta.Name

--- a/pkg/controller/resource/statefulset.go
+++ b/pkg/controller/resource/statefulset.go
@@ -20,9 +20,9 @@ import (
 	"errors"
 	"fmt"
 
-	v1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	appsV1 "k8s.io/api/apps/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	chaosTypes "github.com/litmuschaos/chaos-operator/pkg/controller/types"
 )
@@ -45,8 +45,8 @@ func CheckStatefulSetAnnotation(clientSet *kubernetes.Clientset, ce *chaosTypes.
 }
 
 // getStatefulSetLists will list the statefulset which having the chaos label
-func getStatefulSetLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInfo) (*v1.StatefulSetList, error) {
-	targetAppList, err := clientSet.AppsV1().StatefulSets(ce.AppInfo.Namespace).List(metav1.ListOptions{
+func getStatefulSetLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineInfo) (*appsV1.StatefulSetList, error) {
+	targetAppList, err := clientSet.AppsV1().StatefulSets(ce.AppInfo.Namespace).List(metaV1.ListOptions{
 		LabelSelector: ce.Instance.Spec.Appinfo.Applabel,
 		FieldSelector: ""})
 	if err != nil {
@@ -59,7 +59,7 @@ func getStatefulSetLists(clientSet *kubernetes.Clientset, ce *chaosTypes.EngineI
 }
 
 // This will check and count the total chaos enabled application
-func checkForChaosEnabledStatefulSet(targetAppList *v1.StatefulSetList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
+func checkForChaosEnabledStatefulSet(targetAppList *appsV1.StatefulSetList, ce *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledStatefulSet := 0
 	for _, statefulSet := range targetAppList.Items {
 		ce.AppName = statefulSet.ObjectMeta.Name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Refactor according to the BCH rule 
- Current score is 10/10 (But still require some refactoring)
![Screenshot from 2019-12-31 15-59-01](https://user-images.githubusercontent.com/28861964/71618653-975abc80-2be6-11ea-99ee-8e625e84e421.png)


**Which issue this PR fixes**: fixes https://github.com/litmuschaos/litmus/issues/1041

**Special notes for your reviewer**:
- Trying to keep the PR sort for easy review process

## Log of chaos-operator
```
{"level":"info","ts":1577944152.6691897,"logger":"cmd","msg":"Go Version: go1.13.4"}
{"level":"info","ts":1577944152.6692498,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1577944152.6692646,"logger":"cmd","msg":"Version of operator-sdk: v0.12.0"}
{"level":"info","ts":1577944152.6692677,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1577944153.5137193,"logger":"leader","msg":"No pre-existing lock was found."}
{"level":"info","ts":1577944153.522845,"logger":"leader","msg":"Became the leader."}
{"level":"info","ts":1577944154.4086359,"logger":"metrics","msg":"Metrics Service object created","Service.Name":"chaos-operator-metrics","Service.Namespace":"litmus"}
{"level":"info","ts":1577944155.223713,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}
{"level":"info","ts":1577944155.2243295,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"chaosengine-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1577944155.2245228,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"chaosengine-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1577944155.224646,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"chaosengine-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1577944155.224738,"logger":"cmd","msg":"Starting the Chaos-Operator..."}
{"level":"info","ts":1577944155.2249994,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":1577944155.3252215,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"chaosengine-controller"}
{"level":"info","ts":1577944155.425676,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"chaosengine-controller","worker count":1}

{"level":"info","ts":1577945372.9281392,"logger":"controller_chaosengine","msg":"Reconciling ChaosEngine","Request.Namespace":"default","Request.Name":"nginx-chaos"}
{"level":"info","ts":1577945473.9173603,"logger":"controller_chaosengine","msg":"Reconciling ChaosEngine","Request.Namespace":"default","Request.Name":"nginx-chaos"}
{"level":"info","ts":1577945473.9174588,"logger":"controller_chaosengine","msg":"App key derived from chaosengine is ","appLabelKey":"app"}
{"level":"info","ts":1577945473.9174669,"logger":"controller_chaosengine","msg":"App Label derived from Chaosengine is ","appLabelValue":"nginx"}
{"level":"info","ts":1577945473.917473,"logger":"controller_chaosengine","msg":"App NS derived from Chaosengine is ","appNamespace":"default"}
{"level":"info","ts":1577945473.9174786,"logger":"controller_chaosengine","msg":"Exp list derived from chaosengine is ","appExpirements":["container-kill"]}
{"level":"info","ts":1577945473.9174874,"logger":"controller_chaosengine","msg":"Monitoring Status derived from chaosengine is","monitoringStatus":false}
{"level":"info","ts":1577945473.9174933,"logger":"controller_chaosengine","msg":"Runner image derived from chaosengine is","runnerImage":"litmuschaos/ansible-runner:latest"}
{"level":"info","ts":1577945473.9174993,"logger":"controller_chaosengine","msg":"exporter image derived from chaosengine is","exporterImage":"litmuschaos/chaos-exporter:latest"}
{"level":"info","ts":1577945473.9175055,"logger":"controller_chaosengine","msg":"chaos type is ","chaostype":"app"}
{"level":"info","ts":1577945473.9287455,"logger":"controller_chaosengine","msg":"Deployment chaos candidate:","appName: ":"nginx"," appUUID: ":"669f3a78-2d25-11ea-ab12-42010a800146"}
{"level":"info","ts":1577945473.9288628,"logger":"controller_chaosengine","msg":"chaos candidate of","kind:":"deployment","appName: ":"nginx","appUUID: ":"669f3a78-2d25-11ea-ab12-42010a800146"}
{"level":"info","ts":1577945473.9289258,"logger":"controller_chaosengine","msg":"Creating a new engineRunner Pod","Request.Namespace":"default","Request.Name":"nginx-chaos","Pod.Namespace":"default","Pod.Name":"nginx-chaos-runner"}
{"level":"info","ts":1577945473.9702992,"logger":"controller_chaosengine","msg":"engineRunner Pod created successfully","Request.Namespace":"default","Request.Name":"nginx-chaos"}
{"level":"info","ts":1577945473.9703565,"logger":"controller_chaosengine","msg":"Skip reconcile: engineRunner Pod already exists","Request.Namespace":"default","Request.Name":"nginx-chaos","Pod.Namespace":"","Pod.Name":""}
{"level":"info","ts":1577945473.9703665,"logger":"controller_chaosengine","msg":"Monitoring is disabled","Request.Namespace":"default","Request.Name":"nginx-chaos"}
{"level":"info","ts":1577945473.970401,"logger":"controller_chaosengine","msg":"Reconciling ChaosEngine","Request.Namespace":"default","Request.Name":"nginx-chaos"}
```
```
$ kubectl  get po 
NAME                              READY   STATUS    RESTARTS   AGE
container-kill-bfeae7-nsbq6       1/1     Running   0          54s
nginx-5c7588df-cnvqf              1/1     Running   0          22m
nginx-chaos-runner                1/1     Running   0          85s
pumba-g7ljl                       1/1     Running   0          11s
pumba-grzhn                       1/1     Running   0          11s
pumba-xwgrc                       1/1     Running   0          11s

```
**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests