### PR TITLE
(fix) chaos-operator: Changed Runner Default ENV to use go-executor

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,7 +22,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             #- name: CHAOS_RUNNER_IMAGE
-            #  value: "litmuschaos/ansible-runner:ci"
+            #  value: "litmuschaos/chaos-executor:ci"
             #- name: CHAOS_MONITOR_IMAGE
             #  value: "litmuschaos/chaos-exporter:ci"
             - name: WATCH_NAMESPACE

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -55,7 +55,7 @@ var (
 	DefaultChaosMonitorImage = "litmuschaos/chaos-exporter:latest"
 
 	// DefaultChaosRunnerImage contains the default value of runner resource
-	DefaultChaosRunnerImage = "litmuschaos/ansible-runner:latest"
+	DefaultChaosRunnerImage = "litmuschaos/chaos-executor:latest"
 )
 
 // ApplicationInfo contains the chaos details for target application


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- To understand this change and loogic behind it, please take a look at: `chaosengine_controller.go +571`


**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests