### PR TITLE
(fix) update additional states for engine

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -56,7 +56,7 @@ spec:
               type: string
             engineState: 
               type: string
-              pattern: ^(active|stop)$
+              pattern: ^(active|stop|initialized|stopped)$
             chaosServiceAccount:
               type: string
             components:

--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -55,7 +55,7 @@ spec:
               type: string
             engineState: 
               type: string
-              pattern: ^(active|stop)$
+              pattern: ^(active|stop|initialized|stopped)$
             chaosServiceAccount:
               type: string
             components:


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- The controller patches the engineState with "initialized, stopped" to prevent undesirable reconcile once the respective action has been taken on the user options "active|stop" 
- These states need to be added into the CRD validation schema, failing which - once the runner/monitor are created, the engine cannot be patched afterwards. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests