### PR TITLE
(feat) Added functionality to pass the Args, Commands, and ImagePullPolicy for Runner Pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
 # docker info
-DOCKER_REPO ?= rahulchheda1997
+DOCKER_REPO ?= litmuschaos
 DOCKER_IMAGE ?= chaos-operator
 DOCKER_TAG ?= latest
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
 # docker info
-DOCKER_REPO ?= litmuschaos
+DOCKER_REPO ?= rahulchheda1997
 DOCKER_IMAGE ?= chaos-operator
 DOCKER_TAG ?= latest
 

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -79,18 +79,6 @@ type MonitorInfo struct {
 	Image string `json:"image"`
 }
 
-// PullPolicy describes a policy for if/when to pull a container image
-type PullPolicy string
-
-const (
-	// PullAlways means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
-	PullAlways PullPolicy = "Always"
-	// PullNever means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
-	PullNever PullPolicy = "Never"
-	// PullIfNotPresent means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
-	PullIfNotPresent PullPolicy = "IfNotPresent"
-)
-
 // RunnerInfo defines the information of the runnerinfo pod
 type RunnerInfo struct {
 	//Image of the runner pod

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -78,6 +79,18 @@ type MonitorInfo struct {
 	Image string `json:"image"`
 }
 
+// PullPolicy describes a policy for if/when to pull a container image
+type PullPolicy string
+
+const (
+	// PullAlways means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+	PullAlways PullPolicy = "Always"
+	// PullNever means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+	PullNever PullPolicy = "Never"
+	// PullIfNotPresent means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+	PullIfNotPresent PullPolicy = "IfNotPresent"
+)
+
 // RunnerInfo defines the information of the runnerinfo pod
 type RunnerInfo struct {
 	//Image of the runner pod
@@ -88,6 +101,8 @@ type RunnerInfo struct {
 	Args []string `json:"args,omitempty"`
 	//Command for runner
 	Command []string `json:"command,omitempty"`
+	//ImagePullPolicy for runner pod
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 // ExperimentList defines information about chaos experiments defined in the chaos engine

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -84,6 +84,10 @@ type RunnerInfo struct {
 	Image string `json:"image,omitempty"`
 	//Type of runner
 	Type string `json:"type,omitempty"`
+	//Args of runner
+	Args []string `json:"args,omitempty"`
+	//Command for runner
+	Command []string `json:"command,omitempty"`
 }
 
 // ExperimentList defines information about chaos experiments defined in the chaos engine

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -341,11 +341,10 @@ func newGoRunnerPodForCR(engine chaosTypes.EngineInfo) (*corev1.Pod, error) {
 	containerForRunner := container.NewBuilder().
 		WithEnvsNew(getChaosRunnerENV(engine.Instance, engine.AppExperiments, analytics.ClientUUID)).
 		WithName("chaos-runner").
-		WithImage(engine.Instance.Spec.Components.Runner.Image)
+		WithImage(engine.Instance.Spec.Components.Runner.Image).
+		WithImagePullPolicy(corev1.PullIfNotPresent)
 
-	if engine.Instance.Spec.Components.Runner.ImagePullPolicy == "" {
-		containerForRunner.WithImagePullPolicy(corev1.PullIfNotPresent)
-	} else {
+	if engine.Instance.Spec.Components.Runner.ImagePullPolicy != "" {
 		containerForRunner.WithImagePullPolicy(engine.Instance.Spec.Components.Runner.ImagePullPolicy)
 	}
 
@@ -375,9 +374,7 @@ func newAnsibleRunnerPodForCR(engine chaosTypes.EngineInfo) (*corev1.Pod, error)
 		WithArgumentsNew([]string{"-c", "ansible-playbook ./executor/test.yml -i /etc/ansible/hosts; exit 0"}).
 		WithEnvsNew(getChaosRunnerENV(engine.Instance, engine.AppExperiments, analytics.ClientUUID))
 
-	if engine.Instance.Spec.Components.Runner.ImagePullPolicy == "" {
-		containerForRunner.WithImagePullPolicy(corev1.PullIfNotPresent)
-	} else {
+	if engine.Instance.Spec.Components.Runner.ImagePullPolicy != "" {
 		containerForRunner.WithImagePullPolicy(engine.Instance.Spec.Components.Runner.ImagePullPolicy)
 	}
 

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -338,35 +338,54 @@ func newRunnerPodForCR(ce chaosTypes.EngineInfo) (*corev1.Pod, error) {
 }
 
 func newGoRunnerPodForCR(engine chaosTypes.EngineInfo) (*corev1.Pod, error) {
+	containerForRunner := container.NewBuilder().
+		WithEnvsNew(getChaosRunnerENV(engine.Instance, engine.AppExperiments, analytics.ClientUUID)).
+		WithName("chaos-runner").
+		WithImage(engine.Instance.Spec.Components.Runner.Image).
+		WithImagePullPolicy(corev1.PullIfNotPresent)
+
+	if engine.Instance.Spec.Components.Runner.Args != nil {
+		containerForRunner.WithArgumentsNew(engine.Instance.Spec.Components.Runner.Args)
+	}
+
+	if engine.Instance.Spec.Components.Runner.Command != nil {
+		containerForRunner.WithCommandNew(engine.Instance.Spec.Components.Runner.Command)
+	}
+
 	return pod.NewBuilder().
 		WithName(engine.Instance.Name + "-runner").
 		WithNamespace(engine.Instance.Namespace).
 		WithLabels(map[string]string{"app": engine.Instance.Name, "chaosUID": string(engine.Instance.UID)}).
 		WithServiceAccountName(engine.Instance.Spec.ChaosServiceAccount).
 		WithRestartPolicy("OnFailure").
-		WithContainerBuilder(
-			container.NewBuilder().
-				WithEnvsNew(getChaosRunnerENV(engine.Instance, engine.AppExperiments, analytics.ClientUUID)).
-				WithName("chaos-runner").
-				WithImage(engine.Instance.Spec.Components.Runner.Image).
-				WithImagePullPolicy(corev1.PullIfNotPresent)).Build()
+		WithContainerBuilder(containerForRunner).Build()
 }
 
 func newAnsibleRunnerPodForCR(engine chaosTypes.EngineInfo) (*corev1.Pod, error) {
+	containerForRunner := container.NewBuilder().
+		WithName("chaos-runner").
+		WithImage(engine.Instance.Spec.Components.Runner.Image).
+		WithImagePullPolicy(corev1.PullIfNotPresent).
+		WithCommandNew([]string{"/bin/bash"}).
+		WithArgumentsNew([]string{"-c", "ansible-playbook ./executor/test.yml -i /etc/ansible/hosts; exit 0"}).
+		WithEnvsNew(getChaosRunnerENV(engine.Instance, engine.AppExperiments, analytics.ClientUUID))
+
+	if engine.Instance.Spec.Components.Runner.Args != nil {
+		containerForRunner.WithArgumentsNew(engine.Instance.Spec.Components.Runner.Args)
+	}
+
+	if engine.Instance.Spec.Components.Runner.Command != nil {
+		containerForRunner.WithCommandNew(engine.Instance.Spec.Components.Runner.Command)
+	}
+
 	return pod.NewBuilder().
 		WithName(engine.Instance.Name + "-runner").
 		WithLabels(map[string]string{"app": engine.Instance.Name, "chaosUID": string(engine.Instance.UID)}).
 		WithNamespace(engine.Instance.Namespace).
 		WithRestartPolicy("OnFailure").
 		WithServiceAccountName(engine.Instance.Spec.ChaosServiceAccount).
-		WithContainerBuilder(
-			container.NewBuilder().
-				WithName("chaos-runner").
-				WithImage(engine.Instance.Spec.Components.Runner.Image).
-				WithImagePullPolicy(corev1.PullIfNotPresent).
-				WithCommandNew([]string{"/bin/bash"}).
-				WithArgumentsNew([]string{"-c", "ansible-playbook ./executor/test.yml -i /etc/ansible/hosts; exit 0"}).
-				WithEnvsNew(getChaosRunnerENV(engine.Instance, engine.AppExperiments, analytics.ClientUUID))).Build()
+		WithContainerBuilder(containerForRunner).
+		Build()
 }
 
 // newMonitorPodForCR defines secondary resource #2 in same namespace as CR */

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -341,8 +341,13 @@ func newGoRunnerPodForCR(engine chaosTypes.EngineInfo) (*corev1.Pod, error) {
 	containerForRunner := container.NewBuilder().
 		WithEnvsNew(getChaosRunnerENV(engine.Instance, engine.AppExperiments, analytics.ClientUUID)).
 		WithName("chaos-runner").
-		WithImage(engine.Instance.Spec.Components.Runner.Image).
-		WithImagePullPolicy(corev1.PullIfNotPresent)
+		WithImage(engine.Instance.Spec.Components.Runner.Image)
+
+	if engine.Instance.Spec.Components.Runner.ImagePullPolicy == "" {
+		containerForRunner.WithImagePullPolicy(corev1.PullIfNotPresent)
+	} else {
+		containerForRunner.WithImagePullPolicy(engine.Instance.Spec.Components.Runner.ImagePullPolicy)
+	}
 
 	if engine.Instance.Spec.Components.Runner.Args != nil {
 		containerForRunner.WithArgumentsNew(engine.Instance.Spec.Components.Runner.Args)
@@ -369,6 +374,12 @@ func newAnsibleRunnerPodForCR(engine chaosTypes.EngineInfo) (*corev1.Pod, error)
 		WithCommandNew([]string{"/bin/bash"}).
 		WithArgumentsNew([]string{"-c", "ansible-playbook ./executor/test.yml -i /etc/ansible/hosts; exit 0"}).
 		WithEnvsNew(getChaosRunnerENV(engine.Instance, engine.AppExperiments, analytics.ClientUUID))
+
+	if engine.Instance.Spec.Components.Runner.ImagePullPolicy == "" {
+		containerForRunner.WithImagePullPolicy(corev1.PullIfNotPresent)
+	} else {
+		containerForRunner.WithImagePullPolicy(engine.Instance.Spec.Components.Runner.ImagePullPolicy)
+	}
 
 	if engine.Instance.Spec.Components.Runner.Args != nil {
 		containerForRunner.WithArgumentsNew(engine.Instance.Spec.Components.Runner.Args)


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR is for adding functionality to pass Args and Commands for the RunnerPod    
- Added fields for passing the arguments, and commands to the runner Pod for debug purposes.
- Added fields to pass imagePullPolicy

### Testcases / Considerations

- Override the go command/args 
- Use default command/args (i.e., chaosengine doesn't override) 
-  Override the ansible command/args 
- Use default command/args (i.e., chaosengine doesn't override) 
- What is the CRD validation corresponding to this? 
- BDD corresponding to this (new / changes to existing one) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/litmuschaos/litmus/issues/1215

**Special notes for your reviewer**:
Example Chaos Engine Spec:
```
apiVersion: litmuschaos.io/v1alpha1
kind: ChaosEngine
metadata:
  name: engine
  namespace: litmus
spec:
  engineState: ""
  jobCleanUpPolicy: "delete"
  auxiliaryAppInfo: ""
  components:
    runner:
      image: "litmuschaos/chaos-executor:ci"
      type: "go"
      args: ["rahul"]
      command: ["m","chheda"]
      imagePullPolicy: Always
  appinfo:
    appns: litmus
    applabel: "app=nginx"
    appkind: deployment
  chaosServiceAccount: litmus
  monitoring: true
  experiments:
    - name: node-cpu-hog
```
Runner pod spec:
```
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2020-02-19T09:48:08Z"
  labels:
    app: engine
    chaosUID: 459a8fb6-522b-11ea-9ec5-42010a800213
  name: engine-runner
  namespace: litmus
  resourceVersion: "7420457"
  selfLink: /api/v1/namespaces/litmus/pods/engine-runner
  uid: ef30058a-52fc-11ea-9ec5-42010a800213
spec:
  containers:
  - args:
    - rahul
    command:
    - m
    - chheda
    env:
    - name: CHAOSENGINE
      value: engine
    - name: APP_LABEL
      value: app=nginx
    - name: APP_NAMESPACE
      value: litmus
    - name: EXPERIMENT_LIST
      value: node-cpu-hog
    - name: CHAOS_SVC_ACC
      value: litmus
    - name: AUXILIARY_APPINFO
    - name: CLIENT_UUID
      value: e3b34dac-6fb8-d332-f558-585906cd9fc9
    image: litmuschaos/chaos-executor:ci
    imagePullPolicy: Always
    name: chaos-runner
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: litmus-token-lrjbt
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: gke-rahulchheda-litmus-default-pool-94f0899c-471s
  priority: 0
  restartPolicy: OnFailure
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: litmus
  serviceAccountName: litmus
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: litmus-token-lrjbt
    secret:
      defaultMode: 420
      secretName: litmus-token-lrjbt
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2020-02-19T09:48:08Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2020-02-19T09:48:08Z"
    message: 'containers with unready status: [chaos-runner]'
    reason: ContainersNotReady
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2020-02-19T09:48:08Z"
    message: 'containers with unready status: [chaos-runner]'
    reason: ContainersNotReady
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2020-02-19T09:48:08Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://7a3e519468ae1c87dc46dcd31d274d949605db4323d48a0fdad4263142f8d52c
    image: litmuschaos/chaos-executor:ci
    imageID: docker-pullable://litmuschaos/chaos-executor@sha256:aa6a834570117a6ea86a1f6c2e54ccb04137b47180c1f57aa87f7370278a6910
    lastState:
      terminated:
        containerID: docker://7a3e519468ae1c87dc46dcd31d274d949605db4323d48a0fdad4263142f8d52c
        exitCode: 127
        finishedAt: "2020-02-19T10:29:45Z"
        message: 'OCI runtime create failed: container_linux.go:345: starting container
          process caused "exec: \"m\": executable file not found in $PATH": unknown'
        reason: ContainerCannotRun
        startedAt: "2020-02-19T10:29:45Z"
    name: chaos-runner
    ready: false
    restartCount: 13
    state:
      waiting:
        message: Back-off 5m0s restarting failed container=chaos-runner pod=engine-runner_litmus(ef30058a-52fc-11ea-9ec5-42010a800213)
        reason: CrashLoopBackOff
  hostIP: 10.128.0.98
  phase: Running
  podIP: 10.80.0.2
  qosClass: BestEffort
  startTime: "2020-02-19T09:48:08Z"


```
**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests