### PR TITLE
(feat) Added engineStatus field in ChaosEngine Status

### DIFF
--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -49,6 +49,8 @@ type ChaosEngineSpec struct {
 // +k8s:openapi-gen=true
 // ChaosEngineStatus derives information about status of individual experiments
 type ChaosEngineStatus struct {
+	//
+	EngineStatus string `json:"engineStatus"`
 	//Detailed status of individual experiments
 	Experiments []ExperimentStatuses `json:"experiments"`
 }


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Removed possible states "initialized" and "stopped" from engineState (these states are added by the controller to avoid repeated reconcile operations. However, this is a spec item & should not be modified by the controller)
- Added EngineStatus in Status component of ChaosEngine for above purposes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Needs/Use-cases/Motivation for Status vs State:
- The spec.engineState is now the one which the user patches and Status is the internal status of the chaos-operator.
- Separation of state (user-side) and status (backend-side) was needed, to keep them async.
- Now, after this PR, engineState supports 2 values: active and stop rather than 4.
- Status.engineStatus is internally maintained for internal purposes.
- Reconcile Calls, evaluate both the constraints, PTAL in the file changes.


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests