### PR TITLE
refactor(chaos-result): Remove status subresource from the chaos-result

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -263,8 +263,6 @@ spec:
     plural: chaosresults
     singular: chaosresult
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/crds/chaosresult.yaml
+++ b/deploy/crds/chaosresult.yaml
@@ -5,8 +5,10 @@ metadata:
   # name defined as <chaosengine_name>-<chaosexperiment_name>
   name: engine-nginx-pod-failure
 spec:
-  # holds the state of testcase,  manually updated by json merge patch
-  # result is the useful value today, but anticipate phase use in future 
+  engine: engine-nginx
+  experiment: pod-delete
+  instance: 12345
+status:
   experimentstatus: 
     phase: completed
     verdict: pass

--- a/deploy/crds/chaosresults_crd.yaml
+++ b/deploy/crds/chaosresults_crd.yaml
@@ -10,8 +10,6 @@ spec:
     plural: chaosresults
     singular: chaosresult
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Remove status subresource from the chaos-result

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests