### PR TITLE
(feat) Deletion of Chaos Resources after Completion of Chaos-Runner

### DIFF
--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -39,19 +39,53 @@ type ChaosEngineSpec struct {
 	//Monitor Enable Status
 	Monitoring bool `json:"monitoring,omitempty"`
 	//JobCleanUpPolicy decides to retain or delete the jobs
-	JobCleanUpPolicy string `json:"jobCleanUpPolicy,omitempty"`
+	JobCleanUpPolicy CleanUpPolicy `json:"jobCleanUpPolicy,omitempty"`
 	//AuxiliaryAppInfo contains details of dependent applications (infra chaos)
 	AuxiliaryAppInfo string `json:"auxiliaryAppInfo,omitempty"`
 	//EngineStatus is a requirement for validation
-	EngineState string `json:"engineState"`
+	EngineState EngineState `json:"engineState"`
 }
+
+// EngineState provides interface for all supported strings in spec.EngineState
+type EngineState string
+
+const (
+	// EngineStateActive starts the reconcile call
+	EngineStateActive EngineState = "active"
+	// EngineStateStop stops the reconcile call
+	EngineStateStop EngineState = "stop"
+)
+
+// EngineStatus provides interface for all supported strings in status.EngineStatus
+type EngineStatus string
+
+const (
+	// EngineStatusInitialized is used for reconcile calls to start reconcile for creation
+	EngineStatusInitialized EngineStatus = "initialized"
+	// EngineStatusCompleted is used for reconcile calls to start reconcile for completion
+	EngineStatusCompleted EngineStatus = "completed"
+	// EngineStatusStopped is used for reconcile calls to start reconcile for delete
+	EngineStatusStopped EngineStatus = "stopped"
+)
+
+// CleanUpPolicy defines the garbage collection method used by chaos-operator
+type CleanUpPolicy string
+
+const (
+	//CleanUpPolicyDelete sets the garbage collection policy of chaos-operator to Delete Chaos Resources
+	CleanUpPolicyDelete CleanUpPolicy = "delete"
+
+	//CleanUpPolicyRetain sets the garbage collection policy of chaos-operator to Retain Chaos Resources
+	CleanUpPolicyRetain CleanUpPolicy = "retain"
+)
 
 // ChaosEngineStatus defines the observed state of ChaosEngine
 // +k8s:openapi-gen=true
+
 // ChaosEngineStatus derives information about status of individual experiments
 type ChaosEngineStatus struct {
 	//
-	EngineStatus string `json:"engineStatus"`
+	EngineStatus EngineStatus `json:"engineStatus"`
 	//Detailed status of individual experiments
 	Experiments []ExperimentStatuses `json:"experiments"`
 }

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func() {
 	fmt.Println("chaos-operator created successfully")
 
 	//Wait for the creation of chaos-operator
-	time.Sleep(30 * time.Second)
+	time.Sleep(50 * time.Second)
 
 	//Check for the status of the chaos-operator
 	operator, _ := client.CoreV1().Pods("litmus").List(metav1.ListOptions{LabelSelector: "name=chaos-operator"})
@@ -182,12 +182,13 @@ var _ = Describe("BDD on chaos-operator", func() {
 				},
 				Spec: v1alpha1.ChaosExperimentSpec{
 					Definition: v1alpha1.ExperimentDef{
+						Image: "litmuschaos/ansible-runner:latest",
 
 						Scope: "Namespaced",
 
 						Permissions: []rbacV1.PolicyRule{},
 
-						Args:    []string{"-c", "ansible-playbook ./experiments/chaos/pod_delete/test.yml -i /etc/ansible/hosts -vv; exit 0"},
+						Args:    []string{"-c", "ansible-playbook ./experiments/generic/pod_delete/pod_delete_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0"},
 						Command: []string{"/bin/bash"},
 
 						ENVList: []v1alpha1.ENVPair{
@@ -208,7 +209,7 @@ var _ = Describe("BDD on chaos-operator", func() {
 								Value: "",
 							},
 						},
-						Image: "",
+
 						Labels: map[string]string{
 							"name": "pod-delete",
 						},
@@ -243,8 +244,9 @@ var _ = Describe("BDD on chaos-operator", func() {
 							Type:  "go",
 						},
 					},
-					Monitoring:  true,
-					EngineState: "active",
+					JobCleanUpPolicy: "retain",
+					Monitoring:       true,
+					EngineState:      "active",
 					Experiments: []v1alpha1.ExperimentList{
 						{
 							Name: "pod-delete",
@@ -261,7 +263,7 @@ var _ = Describe("BDD on chaos-operator", func() {
 			fmt.Println("Chaosengine created successfully...")
 
 			//Wait till the creation of runner pod and monitor svc
-			time.Sleep(100 * time.Second)
+			time.Sleep(50 * time.Second)
 
 			//Fetching engine-nginx-runner pod
 			runner, err := client.CoreV1().Pods("litmus").Get("engine-nginx-runner", metav1.GetOptions{})


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adds Logic to check JobCleanUpPolicy
- Adds const strings for JobCleanUpPolicy
- Adds Logic to fetch phase of runner pod
- Changes behaviour of resources deletion using JobCleanUpPolicy and runnerPod Phase. If the runner pod status  is completed, engineStatus is patched to completed and runner pod removed 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes 
 https://github.com/litmuschaos/litmus/issues/1260

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests