### PR TITLE
(refactor) Changed scope of EngineInfo structure from Global to Local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/_output
 *.swp
 *.orig
 .idea/
+coverage.txt

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,0 +1,1 @@
+mode: atomic

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,1 +1,0 @@
-mode: atomic

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -56,15 +56,22 @@ const (
 	EngineStateStop EngineState = "stop"
 )
 
+// ExperimentStatus is typecasted to string for supporting the values below.
 type ExperimentStatus string
 
 const (
-	ExperimentStatusRunning    ExperimentStatus = "Running"
-	ExperimentStatusCompleted  ExperimentStatus = "Completed"
-	ExperimentStatusWaiting    ExperimentStatus = "Waiting for Job Creation"
-	ExperimentStatusNotFound   ExperimentStatus = "ChaosExperiment Not Found"
+	// ExperimentStatusRunning is status of Experiment which is currently running
+	ExperimentStatusRunning ExperimentStatus = "Running"
+	// ExperimentStatusCompleted is status of Experiment which has been completed
+	ExperimentStatusCompleted ExperimentStatus = "Completed"
+	// ExperimentStatusWaiting is status of Experiment which will be executed via a Job
+	ExperimentStatusWaiting ExperimentStatus = "Waiting for Job Creation"
+	// ExperimentStatusNotFound is status of Experiment which is not found inside ChaosNamespace
+	ExperimentStatusNotFound ExperimentStatus = "ChaosExperiment Not Found"
+	// ExperimentStatusSuccessful is status of a Successful experiment execution
 	ExperimentStatusSuccessful ExperimentStatus = "Execution Successful"
-	ExperimentStatusAborted    ExperimentStatus = "Forcefully Aborted"
+	// ExperimentStatusAborted is status of a Experiment is forcefully aborted
+	ExperimentStatusAborted ExperimentStatus = "Forcefully Aborted"
 )
 
 // EngineStatus provides interface for all supported strings in status.EngineStatus
@@ -95,7 +102,7 @@ const (
 
 // ChaosEngineStatus derives information about status of individual experiments
 type ChaosEngineStatus struct {
-	//
+	//EngineStatus is a typed string to support limited values for ChaosEngine Status
 	EngineStatus EngineStatus `json:"engineStatus"`
 	//Detailed status of individual experiments
 	Experiments []ExperimentStatuses `json:"experiments"`

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -123,7 +123,7 @@ func watchChaosResources(clientSet client.Client, c controller.Controller) error
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := startReqLogger(request)
-	var engine &chaosTypes.EngineInfo{}
+	engine := &chaosTypes.EngineInfo{}
 	err := r.getChaosEngineInstance(engine, request)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -423,7 +423,8 @@ func (r *ReconcileChaosEngine) reconcileForDelete(engine *chaosTypes.EngineInfo,
 		r.recorder.Eventf(engine.Instance, corev1.EventTypeWarning, "ChaosResourcesOperationFailed", "Unable to delete chaos resources")
 		return reconcile.Result{}, err
 	}
-	opts := client.UpdateOptions{}
+	//opts := client.UpdateOptions{}
+	patch := client.MergeFrom(engine.Instance.DeepCopy())
 
 	if engine.Instance.ObjectMeta.Finalizers != nil {
 		engine.Instance.ObjectMeta.Finalizers = utils.RemoveString(engine.Instance.ObjectMeta.Finalizers, "chaosengine.litmuschaos.io/finalizer")
@@ -433,7 +434,7 @@ func (r *ReconcileChaosEngine) reconcileForDelete(engine *chaosTypes.EngineInfo,
 	updateExperimentStatusesForStop(engine)
 	engine.Instance.Status.EngineStatus = litmuschaosv1alpha1.EngineStatusStopped
 
-	if err := r.client.Update(context.TODO(), engine.Instance, &opts); err != nil {
+	if err := r.client.Patch(context.TODO(), engine.Instance, patch); err != nil {
 		r.recorder.Eventf(engine.Instance, corev1.EventTypeWarning, "ChaosResourcesOperationFailed", "Unable to update chaosengine")
 		return reconcile.Result{}, fmt.Errorf("Unable to remove Finalizer from chaosEngine Resource, due to error: %v", err)
 	}

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -423,7 +423,6 @@ func (r *ReconcileChaosEngine) reconcileForDelete(engine *chaosTypes.EngineInfo,
 		r.recorder.Eventf(engine.Instance, corev1.EventTypeWarning, "ChaosResourcesOperationFailed", "Unable to delete chaos resources")
 		return reconcile.Result{}, err
 	}
-	//opts := client.UpdateOptions{}
 	patch := client.MergeFrom(engine.Instance.DeepCopy())
 
 	if engine.Instance.ObjectMeta.Finalizers != nil {

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -123,7 +123,7 @@ func watchChaosResources(clientSet client.Client, c controller.Controller) error
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := startReqLogger(request)
-	engine := InitEngineInfo()
+	var engine &chaosTypes.EngineInfo{}
 	err := r.getChaosEngineInstance(engine, request)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -666,9 +666,4 @@ func (r *ReconcileChaosEngine) forceRemoveChaosResources(engine *chaosTypes.Engi
 		return err
 	}
 	return nil
-}
-
-// InitEngineInfo provides reference to a new
-func InitEngineInfo() *chaosTypes.EngineInfo {
-	return &chaosTypes.EngineInfo{}
 }

--- a/pkg/controller/resource/deploymentconfig.go
+++ b/pkg/controller/resource/deploymentconfig.go
@@ -19,7 +19,8 @@ var (
 		Resource: "deploymentconfigs",
 	}
 )
-// CheckDeploymentAnnotation will check the annotation of deployment
+
+// CheckDeploymentConfigAnnotation will check the annotation of deployment
 func CheckDeploymentConfigAnnotation(clientSet dynamic.Interface, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, error) {
 
 	deploymentConfigList, err := getDeploymentConfigList(clientSet, engine)

--- a/pkg/controller/resource/resource.go
+++ b/pkg/controller/resource/resource.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"strings"
 
-	dynamic "github.com/litmuschaos/chaos-operator/pkg/dynamic"
 	chaosTypes "github.com/litmuschaos/chaos-operator/pkg/controller/types"
+	dynamic "github.com/litmuschaos/chaos-operator/pkg/dynamic"
 	k8s "github.com/litmuschaos/chaos-operator/pkg/kubernetes"
 )
 

--- a/pkg/dynamic/dynamic.go
+++ b/pkg/dynamic/dynamic.go
@@ -5,7 +5,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-func CreateClientSet() (*dynamic.Interface, error){
+// CreateClientSet returns a Dynamic Kubernetes ClientSet
+func CreateClientSet() (*dynamic.Interface, error) {
 	restConfig, err := config.GetConfig()
 	if err != nil {
 		return nil, err

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -442,7 +442,28 @@ var _ = Describe("BDD on chaos-operator", func() {
 //Deleting all unused resources
 var _ = AfterSuite(func() {
 
-	By("Deleting all CRDs")
-	crdDeletion := exec.Command("kubectl", "delete", "-f", "../../deploy/chaos_crds.yaml").Run()
-	Expect(crdDeletion).To(BeNil())
+	//Deleting ChaosExperiments
+	By("Deleting ChaosExperiments")
+	err = exec.Command("kubectl", "delete", "chaosexperiments", "--all", "-n", "litmus").Run()
+	Expect(err).To(BeNil())
+
+	//Deleting ChaosEngines
+	By("Deleting ChaosEngines")
+	err = exec.Command("kubectl", "delete", "chaosengine", "--all", "-n", "litmus").Run()
+	Expect(err).To(BeNil())
+
+	//Deleting CRD's
+	By("deleting chaosengine crd")
+	err = exec.Command("kubectl", "delete", "-f", "../../deploy/chaos_crds.yaml").Run()
+	Expect(err).To(BeNil())
+
+	//Deleting rbacs
+	err = exec.Command("kubectl", "delete", "-f", "../../deploy/rbac.yaml").Run()
+	Expect(err).To(BeNil())
+
+	//Deleting Chaos-Operator
+	By("Deleting operator")
+	err = exec.Command("kubectl", "delete", "-f", "../../deploy/operator.yaml").Run()
+	Expect(err).To(BeNil())
+
 })

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -452,9 +452,9 @@ var _ = AfterSuite(func() {
 	err = exec.Command("kubectl", "delete", "chaosengine", "--all", "-n", "litmus").Run()
 	Expect(err).To(BeNil())
 
-	//Deleting CRD's
-	By("deleting chaosengine crd")
-	err = exec.Command("kubectl", "delete", "-f", "../../deploy/chaos_crds.yaml").Run()
+	//Deleting Chaos-Operator
+	By("Deleting operator")
+	err = exec.Command("kubectl", "delete", "-f", "../../deploy/operator.yaml").Run()
 	Expect(err).To(BeNil())
 
 	//Deleting rbacs
@@ -462,9 +462,9 @@ var _ = AfterSuite(func() {
 	err = exec.Command("kubectl", "delete", "-f", "../../deploy/rbac.yaml").Run()
 	Expect(err).To(BeNil())
 
-	//Deleting Chaos-Operator
-	By("Deleting operator")
-	err = exec.Command("kubectl", "delete", "-f", "../../deploy/operator.yaml").Run()
+	//Deleting CRD's
+	By("Deleting chaosengine crd")
+	err = exec.Command("kubectl", "delete", "-f", "../../deploy/chaos_crds.yaml").Run()
 	Expect(err).To(BeNil())
 
 })

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -410,21 +410,20 @@ var _ = Describe("BDD on chaos-operator", func() {
 			)
 
 			fmt.Printf("Got Pod Name: %v\n", podName)
+
 			podLogOpts := v1.PodLogOptions{}
+
 			req := client.CoreV1().Pods("litmus").GetLogs(podName, &podLogOpts)
+
 			podLogs, err := req.Stream()
 			Expect(err).To(BeNil())
-			// if err != nil {
-			// 	return "error in opening stream"
-			// }
+
 			defer podLogs.Close()
 
 			buf := new(bytes.Buffer)
 			_, err = io.Copy(buf, podLogs)
 			Expect(err).To(BeNil())
-			// if err != nil {
-			// 	return "error in copy information from podLogs to buf"
-			// }
+
 			str := buf.String()
 
 			fmt.Printf("%v\n", str)

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"regexp"
 	"testing"
 	"time"
 
@@ -37,6 +36,7 @@ import (
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 
 	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 	chaosClient "github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/typed/litmuschaos/v1alpha1"
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func() {
 	err = exec.Command("kubectl", "apply", "-f", "../../deploy/operator.yaml").Run()
 	Expect(err).To(BeNil())
 
-	fmt.Println("chaos-operator created successfully")
+	klog.Infoln("chaos-operator created successfully")
 
 	//Wait for the creation of chaos-operator
 	time.Sleep(50 * time.Second)
@@ -154,7 +154,7 @@ var _ = Describe("BDD on chaos-operator", func() {
 
 			_, err := client.AppsV1().Deployments("litmus").Create(deployment)
 			if err != nil {
-				fmt.Println("Deployment is not created and error is ", err)
+				klog.Infoln("Deployment is not created and error is ", err)
 			}
 
 			//creating chaos-experiment for pod-delete
@@ -207,7 +207,7 @@ var _ = Describe("BDD on chaos-operator", func() {
 			_, err = clientSet.ChaosExperiments("litmus").Create(ChaosExperiment)
 			Expect(err).To(BeNil())
 
-			fmt.Println("ChaosExperiment created successfully...")
+			klog.Infoln("ChaosExperiment created successfully...")
 
 			//Creating chaosEngine
 			By("Creating ChaosEngine")
@@ -243,7 +243,7 @@ var _ = Describe("BDD on chaos-operator", func() {
 			_, err = clientSet.ChaosEngines("litmus").Create(chaosEngine)
 			Expect(err).To(BeNil())
 
-			fmt.Println("Chaosengine created successfully...")
+			klog.Infoln("Chaosengine created successfully...")
 
 			//Wait till the creation of runner pod
 			time.Sleep(50 * time.Second)
@@ -278,7 +278,7 @@ var _ = Describe("BDD on chaos-operator", func() {
 			_, err = clientSet.ChaosEngines("litmus").Update(engine)
 			Expect(err).To(BeNil())
 
-			fmt.Println("Chaosengine updated successfully...")
+			klog.Infoln("Chaosengine updated successfully...")
 
 			//Wait till the creation of runner pod
 			time.Sleep(50 * time.Second)
@@ -293,10 +293,10 @@ var _ = Describe("BDD on chaos-operator", func() {
 
 			//Fetching engine-nginx-runner pod
 			_, err := client.CoreV1().Pods("litmus").Get("engine-nginx-runner", metav1.GetOptions{})
-			fmt.Printf("%v", err)
+			klog.Infof("%v\n", err)
 			isNotFound := errors.IsNotFound(err)
 			Expect(isNotFound).To(BeTrue())
-			fmt.Println("chaos-runner pod deletion verified")
+			klog.Infoln("chaos-runner pod deletion verified")
 
 		})
 
@@ -318,7 +318,7 @@ var _ = Describe("BDD on chaos-operator", func() {
 			err := clientSet.ChaosEngines("litmus").Delete("engine-nginx", &metav1.DeleteOptions{})
 			Expect(err).To(BeNil())
 
-			fmt.Println("chaos engine deleted successfully")
+			klog.Infoln("chaos engine deleted successfully")
 
 		})
 
@@ -373,10 +373,10 @@ var _ = Describe("BDD on chaos-operator", func() {
 
 			//Fetching engine-nginx-runner pod
 			_, err := client.CoreV1().Pods("litmus").Get("engine-nginx-runner", metav1.GetOptions{})
-			fmt.Printf("%v", err)
+			klog.Infof("%v\n", err)
 			isNotFound := errors.IsNotFound(err)
 			Expect(isNotFound).To(BeTrue())
-			fmt.Println("chaos-runner pod deletion verified")
+			klog.Infoln("chaos-runner pod deletion verified")
 
 		})
 
@@ -395,21 +395,27 @@ var _ = Describe("BDD on chaos-operator", func() {
 	Context("Validate via Chaos-Operator Logs", func() {
 
 		It("Should Generate Operator logs", func() {
-			pods, err := client.CoreV1().Pods("litmus").List(metav1.ListOptions{})
+			pods, err := client.CoreV1().Pods("litmus").List(metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%v=%v","name","chaos-operator"),
+			})
 			Expect(err).To(BeNil())
-			var podName string
-			for i := range pods.Items {
-				matched, _ := regexp.MatchString("litmus-*", pods.Items[i].Name)
-				if matched == true {
-					podName = pods.Items[i].Name
-				}
+
+			if len(pods.Items) > 1 {
+				klog.Infof("Multiple Chaos-Operator Pods found")
+				return
 			}
+			if len(pods.Items) < 1 {
+				klog.Infof("Unable to find Chaos-Operator Pod")
+				return
+			}
+
+			podName := pods.Items[0].Name
 			Expect(podName).To(
 				Not(BeEmpty()),
-				"Unable to get the pod, might be something wrong with chaos-operator BDD",
+				"Unable to get the operator pod name",
 			)
 
-			fmt.Printf("Got Pod Name: %v\n", podName)
+			klog.Infof("Got Pod Name: %v\n", podName)
 
 			podLogOpts := v1.PodLogOptions{}
 
@@ -426,7 +432,7 @@ var _ = Describe("BDD on chaos-operator", func() {
 
 			str := buf.String()
 
-			fmt.Printf("%v\n", str)
+			klog.Infof("Chaos Operator Logs:\n%v\n", str)
 
 		})
 	})

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -444,7 +444,7 @@ var _ = AfterSuite(func() {
 
 	//Deleting ChaosExperiments
 	By("Deleting ChaosExperiments")
-	err = exec.Command("kubectl", "delete", "chaosexperiments", "--all", "-n", "litmus").Run()
+	err := exec.Command("kubectl", "delete", "chaosexperiments", "--all", "-n", "litmus").Run()
 	Expect(err).To(BeNil())
 
 	//Deleting ChaosEngines

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -396,7 +396,7 @@ var _ = Describe("BDD on chaos-operator", func() {
 
 		It("Should Generate Operator logs", func() {
 			pods, err := client.CoreV1().Pods("litmus").List(metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("%v=%v","name","chaos-operator"),
+				LabelSelector: fmt.Sprintf("%v=%v", "name", "chaos-operator"),
 			})
 			Expect(err).To(BeNil())
 

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -458,6 +458,7 @@ var _ = AfterSuite(func() {
 	Expect(err).To(BeNil())
 
 	//Deleting rbacs
+	By("Deleting RBAC's")
 	err = exec.Command("kubectl", "delete", "-f", "../../deploy/rbac.yaml").Run()
 	Expect(err).To(BeNil())
 


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- In this PR, we have converted the global EngineInfo variable, to local variable.
- There was an issue in chaos-operator where the client-go k8s api-server calls to perform CRUD operations on ChaosEngine, sometimes failed and caused chaos-operator error logs.
- This was because of change in resourceVersion of ChaosEngine resource, because both the Global Variable of EngineInfo, and local instances of EngineInfo were not in sync before make k8s client-go operations.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests