### PR TITLE
(fix)controller: propagate annotation check failure to reconciler

### DIFF
--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -635,7 +635,7 @@ func (r *ReconcileChaosEngine) validateAnnontatedApplication(engine *chaosTypes.
 		if err != nil {
 			r.recorder.Eventf(engine.Instance, corev1.EventTypeWarning, "ChaosResourcesOperationFailed", "Unable to get chaosengine")
 			chaosTypes.Log.Info("Annotation check failed with", "error:", err)
-			return nil
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #211 

**Special notes for your reviewer**:

#### Following cases were tested: 

-  Inhibits chaos when (with .spec.annotationCheck = "true" in engine): 

   - No chaos annotation (litmuschaos.io/chaos: "true") set of  app spec
   - Annotation value set to "false"
   - Annotation value set to neither true/false
 
-  Runs chaos when: 

   - .spec.annotationCheck is set to "false"
   - .spec.annotationCheck is set to "true" & app is annotated with "litmuschaos.io/chaos: true"

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests