### PR TITLE
(enhancement)types: add ImagePullPolicy as an experiment CR attribute

### DIFF
--- a/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
@@ -56,8 +56,10 @@ type ExperimentDef struct {
 	// Default labels of the runner pod
 	// +optional
 	Labels map[string]string `json:"labels"`
-	// Image of the chaos executor
+	// Image of the chaos experiment
 	Image string `json:"image"`
+	// ImagePullPolicy of the chaos experiment container
+	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
 	//Scope specifies the service account scope (& thereby blast radius) of the experiment
 	Scope string `json:"scope"`
 	// List of Permission needed for a service account to execute experiment


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Some of the developer workflows of litmus (i.e., usage in CI/CD pipelines) require that the experiment image is locally sourced, which in turn needs an imagePullPolicy to be set as IfNotPresent. 
- Currently, the experiment image pull policy is hardcoded to "Always" during bring up of experiment job (by chaos-runner)
- This PR makes it a tunable within the experiment schema


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- Will be followed by PRs on chaos-runner & chaos-charts to derive the value from the experiment spec and set it in the builder functions used for creating the exp job

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests