### PR TITLE
feat(security-context): adding the security context in experiment CR

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -264,6 +264,8 @@ spec:
                         type: string
                         allowEmptyValue: false
                         minLength: 1
+                securityContext:
+                  type: object
         status:
           type: object
   version: v1alpha1

--- a/deploy/crds/chaosexperiment_crd.yaml
+++ b/deploy/crds/chaosexperiment_crd.yaml
@@ -116,6 +116,8 @@ spec:
                         type: string
                         allowEmptyValue: false
                         minLength: 1
+                securityContext:
+                  type: object
         status:
           type: object
   version: v1alpha1

--- a/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
@@ -77,6 +77,8 @@ type ExperimentDef struct {
 	Secrets []Secret `json:"secrets,omitempty"`
 	// Annotations that needs to be provided in the pod for pod that is getting created
 	ExperimentAnnotations map[string]string `json:"experimentannotations,omitempty"`
+	// SecurityContext holds security configuration that will be applied to a container
+	SecurityContext corev1.SecurityContext `json:"securityContext,omitempty"`
 }
 
 // ENVPair defines env var list to hold chaos params

--- a/pkg/apis/litmuschaos/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/litmuschaos/v1alpha1/zz_generated.deepcopy.go
@@ -486,6 +486,7 @@ func (in *ExperimentDef) DeepCopyInto(out *ExperimentDef) {
 			(*out)[key] = val
 		}
 	}
+	in.SecurityContext.DeepCopyInto(&out.SecurityContext)
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding the security context in the chaos experiment CR so that we can bypass those security context to the chaos-pod and create the chaos pod those features.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes litmuschaos/litmus#1594
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests