### PR TITLE
chore(CI): Add GitHub CI to run on demand operator BDDs

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,24 @@
+# Configuration for probot-auto-merge - https://github.com/bobvanderlinden/probot-auto-merge
+
+reportStatus: true
+updateBranch: false
+deleteBranchAfterMerge: true
+mergeMethod: squash
+
+minApprovals:
+  COLLABORATOR: 0
+maxRequestedChanges:
+  NONE: 0
+blockingLabels:
+- DO NOT MERGE
+- WIP
+- blocked
+
+# Will merge whenever the above conditions are met, but also
+# the owner has approved or merge label was added.
+rules:
+- minApprovals:
+    OWNER: 1
+- requiredLabels:
+  - merge
+  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,158 @@
+name: ChaosOperator-CI
+on:
+  issue_comment:
+    types: [created]
+ 
+jobs:
+  tests:
+    if: contains(github.event.comment.html_url, '/pull/') && startsWith(github.event.comment.body, '/run-e2e')
+    runs-on: ubuntu-latest
+    steps:
+ 
+      - name: Notification for e2e Start
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: "${{ github.event.comment.id }}"
+          body: |
+            ****
+            **Test Status:** The e2e test has been started please wait for the results ...     
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.13.1'
+ 
+      - name: Setting up GOPATH 
+        run: |
+          echo ::set-env name=GOPATH::${GITHUB_WORKSPACE}/go
+
+      #Using the last commit id of pull request
+      - uses: octokit/request-action@v2.x
+        id: get_PR_commits
+        with:
+          route: GET /repos/:repo/pulls/:pull_number/commits
+          repo: ${{ github.repository }}
+          pull_number: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ 
+      - name: set commit to output
+        id: getcommit
+        run: | 
+           prsha=$(echo $response | jq '.[-1].sha'  | tr -d '"')
+           echo "::set-output name=sha::$prsha" 
+        env: 
+          response:  ${{ steps.get_PR_commits.outputs.data }}
+          
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{steps.getcommit.outputs.sha}}
+          path: go/src/github.com/litmuschaos/chaos-operator
+          
+      - name: Build docker image
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          cd ${GOPATH}/src/github.com/litmuschaos/chaos-operator 
+          make build
+          sudo docker build -f build/Dockerfile -t litmuschaos/chaos-operator:ci .
+
+      #Install and configure a kind cluster
+      - name: Installing Prerequisites (KinD Cluster)
+        uses: engineerd/setup-kind@v0.4.0
+        with:
+            version: "v0.7.0"
+ 
+      - name: Configuring and testing kind Installation
+        run: |
+          kubectl cluster-info --context kind-kind
+          kind get kubeconfig --internal >$HOME/.kube/config
+          kubectl get nodes
+
+      - name: Load image on the nodes of the cluster
+        run: |
+          kind load docker-image --name=kind litmuschaos/chaos-operator:ci
+
+      - name: Getting litmus-e2e repository
+        run: |
+          cd ${GOPATH}/src/github.com/litmuschaos/
+          git clone https://github.com/litmuschaos/litmus-e2e.git -b generic
+
+      - name: Install LitmusChaos
+        run: | 
+          export PATH=$PATH:$(go env GOPATH)/bin
+          cd ${GOPATH}/src/github.com/litmuschaos/litmus-e2e
+          go test tests/install-litmus_test.go -v -count=1
+        env:
+          OPERATOR_IMAGE: litmuschaos/chaos-operator:ci
+          IMAGE_PULL_POLICY: IfNotPresent
+ 
+      - name: Run Admin mode test
+        if: startsWith(github.event.comment.body, '/run-e2e-admin-mode') || startsWith(github.event.comment.body, '/run-e2e-all')
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          cd ${GOPATH}/src/github.com/litmuschaos/litmus-e2e
+          go test operator/admin-mode_test.go -v -count=1
+
+      - name: Run Reconcile Resiliency test
+        if: startsWith(github.event.comment.body, '/run-e2e-reconcile-resiliency') || startsWith(github.event.comment.body, '/run-e2e-all')
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          cd ${GOPATH}/src/github.com/litmuschaos/litmus-e2e
+          go test operator/reconcile-resiliency_test.go -v -count=1
+
+      - name: Check the test run
+        if: |
+         startsWith(github.event.comment.body, '/run-e2e-admin-mode') || startsWith(github.event.comment.body, '/run-e2e-reconcile-resiliency') ||
+         startsWith(github.event.comment.body, '/run-e2e-all')
+        run: |
+          echo ::set-env name=TEST_RUN::true
+
+      - name: Check for all the jobs are succeeded
+        if: ${{ success() && env.TEST_RUN == 'true' }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: "${{ github.event.comment.id }}"
+          body: |  
+            **Test Result:** All tests are passed
+            **Run ID:** [${{ env.RUN_ID }}](https://github.com/litmuschaos/chaos-operator/actions/runs/${{ env.RUN_ID }})                        
+           
+          reactions: hooray         
+        env: 
+          RUN_ID: ${{ github.run_id }}
+ 
+      - name: Check for any job failed
+        if: ${{ failure() }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: "${{ github.event.comment.id }}"
+          body: |
+            **Test Failed:** Some tests are failed please check
+            **Run ID:** [${{ env.RUN_ID }}](https://github.com/litmuschaos/chaos-operator/actions/runs/${{ env.RUN_ID }})            
+          reactions: confused
+        env: 
+          RUN_ID: ${{ github.run_id }}
+ 
+      - name: Deleting KinD cluster
+        if: ${{ always() }}
+        run: kind delete cluster
+ 
+      - name: Check if any test ran or not
+        if: env.TEST_RUN != 'true'
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: "${{ github.event.comment.id }}"
+          body: |
+            **Test Result:** No test found
+            **Run ID:** [${{ env.RUN_ID }}](https://github.com/litmuschaos/chaos-operator/actions/runs/${{ env.RUN_ID }})
+          reactions: eyes
+        env: 
+          RUN_ID: ${{ github.run_id }}
+ 
+  merge:
+    if: contains(github.event.comment.html_url, '/pull/') && startsWith(github.event.comment.body, '/merge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add a merge label when all jobs are passed
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          labels: merge


### PR DESCRIPTION
Signed-off-by: Udit Gaurav udit.gaurav@mayadata.io

**What this PR does / why we need it**:
This PR is for:
- Adding GitHub CI workflow for chaos operator repository which will run on demand operator BDDs before merging a PR. It will be helpful to test the PRs before merging. We can call a test using `/run-e2e-<testname>`.
- Adding merge label for an issue comment `/merge` which will be further taken by pro bot to merge the PR.
- Added link of the job as a result of the CI run. 

**Which issue this PR fixes**
fixes: https://github.com/litmuschaos/litmus/issues/1628 and https://github.com/litmuschaos/litmus/issues/1627

**Special notes for your reviewer**:
- Install [auto-merge-pro-bot](https://github.com/apps/probot-auto-merge) in this repository to merge a PR by checking `/merge` comment along with some approved Review.