### PR TITLE
(enhancement)types: enhance the engineStatus schema to hold more run details

### DIFF
--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -184,8 +184,12 @@ type ExperimentENV struct {
 // ExperimentStatuses defines information about status of individual experiments
 // These fields are immutable, and are derived by kubernetes(operator)
 type ExperimentStatuses struct {
-	//Name of experiment whose status is detailed
+	//Name of the chaos experiment 
 	Name string `json:"name"`
+	//Name of chaos-runner pod managing this experiment
+	Runner string `json:"runner"`
+	//Name of experiment pod executing the chaos
+	ExpPod string `json:"experimentPod"`
 	//Current state of chaos experiment
 	Status ExperimentStatus `json:"status"`
 	//Result of a completed chaos experiment


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Enhances the ChaosEngine Status schema to hold more information about the experiment in terms of experiment name, runner launching this experiment & the experiment pod executing the chaos.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # (partially fulfills #250 )

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests