### PR TITLE
(fix)controller: fix engine status updates upon app filter failure

### DIFF
--- a/deploy/01-chaos-operator.yaml
+++ b/deploy/01-chaos-operator.yaml
@@ -124,6 +124,7 @@ spec:
                   type: string
                   pattern: ^(deployment|statefulset|daemonset|deploymentconfig)$
                 applabel:
+                  pattern: ([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)
                   type: string
                 appns:
                   type: string

--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -49,6 +49,7 @@ spec:
                   pattern: ^(deployment|statefulset|daemonset|deploymentconfig)$
                 applabel:
                   type: string
+                  pattern: ([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)
                 appns:
                   type: string
             auxiliaryAppInfo:

--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -47,6 +47,7 @@ spec:
                   type: string
                   pattern: ^(deployment|statefulset|daemonset|deploymentconfig)$
                 applabel:
+                  pattern: ([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)
                   type: string
                 appns:
                   type: string

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -612,13 +612,11 @@ func (r *ReconcileChaosEngine) reconcileForCreationAndRunning(engine *chaosTypes
 
 	err := r.validateAnnontatedApplication(engine)
 	if err != nil {
-		//return reconcile.Result{}, err
 		stop_engine_with_annotation_error_message := r.updateEngineState(engine, litmuschaosv1alpha1.EngineStateStop)
 		if stop_engine_with_annotation_error_message != nil {
 			r.recorder.Eventf(engine.Instance, corev1.EventTypeWarning, "ChaosResourcesOperationFailed", "Unable to update chaosengine")
 			return reconcile.Result{}, fmt.Errorf("Unable to Update Engine State: %v", err)
 		}
-		//do we return error ? 
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Patches the engine status with appropriate status (stopped) along with right event messages to indicate that the chaos resources won't be launched in case of failed app identification

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/litmuschaos/litmus/issues/1828

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests