### PR TITLE
(enhance)controller: default to the chaosengine resource namespace if app namespace is not specified

### DIFF
--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -172,6 +172,15 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 
 // getChaosRunnerENV return the env required for chaos-runner
 func getChaosRunnerENV(cr *litmuschaosv1alpha1.ChaosEngine, aExList []string, ClientUUID string) []corev1.EnvVar {
+
+	var appNS string
+
+	if cr.Spec.Appinfo.Appns != "" {
+        appNS = cr.Spec.Appinfo.Appns
+    } else {
+        appNS = cr.Namespace
+    }
+
 	return []corev1.EnvVar{
 		{
 			Name:  "CHAOSENGINE",
@@ -183,7 +192,7 @@ func getChaosRunnerENV(cr *litmuschaosv1alpha1.ChaosEngine, aExList []string, Cl
 		},
 		{
 			Name:  "APP_NAMESPACE",
-			Value: cr.Spec.Appinfo.Appns,
+			Value: appNS,
 		},
 		{
 			Name:  "EXPERIMENT_LIST",
@@ -248,7 +257,13 @@ func initializeApplicationInfo(instance *litmuschaosv1alpha1.ChaosEngine, appInf
 	chaosTypes.AppLabelValue = appLabel[1]
 	appInfo.Label = make(map[string]string)
 	appInfo.Label[chaosTypes.AppLabelKey] = chaosTypes.AppLabelValue
-	appInfo.Namespace = instance.Spec.Appinfo.Appns
+
+	if instance.Spec.Appinfo.Appns != "" {
+		appInfo.Namespace = instance.Spec.Appinfo.Appns
+	} else {
+		appInfo.Namespace = instance.Namespace
+	}
+
 	appInfo.ExperimentList = instance.Spec.Experiments
 	appInfo.ServiceAccountName = instance.Spec.ChaosServiceAccount
 	appInfo.Kind = instance.Spec.Appinfo.AppKind


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adds default Kubernetes pattern of looking for target application in the same namespace where the chaosengine resource is created, if the `.spec.appinfo.appns` is not explicitly specified. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #255 

**Special notes for your reviewer**:

- We haven't made the attribute omitempty, just so we get a bit more visibility in terms of spec/debug. Takes it as an empty "" irrespective of this (we will see it empty in the spec now). Open to thoughts/changes. 

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests