### PR TITLE
feat(multiarch): Add multi-arch support for chaos operator image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
 
   build:
     machine: 
-      image: circleci/classic:201808-01
+      image: ubuntu-1604:202007-01
     working_directory: ~/go/src/github.com/litmuschaos/chaos-operator
     environment:
       K8S_VERSION: v1.12.0
@@ -17,13 +17,28 @@ jobs:
       CHANGE_MINIKUBE_NONE_USER: true
       REPONAME: litmuschaos
       IMGNAME: chaos-operator
-      IMGTAG: ci
+      IMGTAG: dev
     steps:
       - checkout
+      
+      - run: 
+          name: Setup buildx
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx version
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            sudo apt-get update && sudo apt-get install qemu-user-static -y
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes i
+            docker buildx create --name multibuilder
+            docker buildx inspect multibuilder --bootstrap
+            docker buildx use multibuilder
+       
       - run:
-         name: Setup kubectl
-         command: | 
-           curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+          name: Setup kubectl
+          command: | 
+            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - run:
           name: Setup minikube
           command: |
@@ -41,38 +56,47 @@ jobs:
             echo 'export PATH="$GOPATH/bin:$PATH"' >> workspace/env-vars
             echo 'export REPONAME="litmuschaos"' >> workspace/env-vars
             echo 'export IMGNAME="chaos-operator"' >> workspace/env-vars
-            echo 'export IMGTAG="ci"' >> workspace/env-vars
+            echo 'export IMGTAG="dev"' >> workspace/env-vars
             cat workspace/env-vars >> $BASH_ENV
             source $BASH_ENV
       - run: make deps
       - run: make gotasks
-      - run: |
-          docker build . -f build/Dockerfile -t ${REPONAME}/${IMGNAME}:${IMGTAG}
+      - run: |   
+          docker buildx build --file build/Dockerfile --progress plane --platform linux/arm64,linux/amd64 --tag ${REPONAME}/${IMGNAME}:${IMGTAG} .    
       - run: make test 
-      - run: |
-          docker save -o workspace/image.tar ${REPONAME}/${IMGNAME}:${IMGTAG}
-      - run: bash <(curl -s https://codecov.io/bash) -vz 
-      - persist_to_workspace:
-          root: workspace 
-          paths: 
-            - image.tar
-            - env-vars
 
   push:
     machine: 
-      image: circleci/classic:201808-01
+      image: ubuntu-1604:202007-01
     environment:
-      IMGTAG: ci
+      IMGTAG: dev
     working_directory: ~/go/src/github.com/litmuschaos/chaos-operator
     steps: 
       - attach_workspace:
           at: /tmp/workspace
-      - run: |
-          cat /tmp/workspace/env-vars >> $BASH_ENV
       - checkout
-      - run: |
-          docker load -i /tmp/workspace/image.tar
-          ~/go/src/github.com/litmuschaos/chaos-operator/buildscripts/push --type=ci
+
+      - run: 
+          name: Setup buildx
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx version
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            sudo apt-get update && sudo apt-get install qemu-user-static -y
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes i
+            docker buildx create --name multibuilder
+            docker buildx inspect multibuilder --bootstrap
+            docker buildx use multibuilder
+
+      - run: 
+          name: push
+          command: ~/go/src/github.com/litmuschaos/chaos-operator/buildscripts/push --type=dev
+          environment:
+            REPONAME: litmuschaos
+            IMGNAME: chaos-operator
+            IMGTAG: dev
 
   trivy-check:
     machine: true
@@ -87,24 +111,40 @@ jobs:
           wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-${TRIVYARCH}.tar.gz
           tar zxvf trivy_${VERSION}_Linux-${TRIVYARCH}.tar.gz
       - run: |
-          ./trivy --exit-code 0 --severity HIGH --no-progress litmuschaos/chaos-operator:ci
-          ./trivy --exit-code 0 --severity CRITICAL --no-progress litmuschaos/chaos-operator:ci
+          ./trivy --exit-code 0 --severity HIGH --no-progress litmuschaos/chaos-operator:dev
+          ./trivy --exit-code 0 --severity CRITICAL --no-progress litmuschaos/chaos-operator:dev
           
   release: 
     machine: 
-      image: circleci/classic:201808-01
+      image: ubuntu-1604:202007-01
     environment:
-      IMGTAG: ci
+      IMGTAG: dev
     working_directory: ~/go/src/github.com/litmuschaos/chaos-operator
     steps: 
       - attach_workspace:
           at: /tmp/workspace
-      - run: |
-          cat /tmp/workspace/env-vars >> $BASH_ENV
       - checkout 
-      - run: | 
-          docker load -i /tmp/workspace/image.tar
-          ~/go/src/github.com/litmuschaos/chaos-operator/buildscripts/push --type=release
+      - run: 
+          name: Setup buildx
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx version
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            sudo apt-get update && sudo apt-get install qemu-user-static -y
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes i
+            docker buildx create --name multibuilder
+            docker buildx inspect multibuilder --bootstrap
+            docker buildx use multibuilder
+
+      - run:
+          name: release push
+          command: ~/go/src/github.com/litmuschaos/chaos-operator/buildscripts/push --type=release
+          environment:
+            REPONAME: litmuschaos
+            IMGNAME: chaos-operator
+            IMGTAG: dev      
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build:
 	@echo "------------------"
 	@echo "--> Build Chaos Operator"
 	@echo "------------------"
-	@go build -o ${GOPATH}/src/github.com/litmuschaos/chaos-operator/build/_output/bin/chaos-operator -gcflags all=-trimpath=${GOPATH} -asmflags all=-trimpath=${GOPATH} github.com/litmuschaos/chaos-operator/cmd/manager
+	@./build/go-multiarch-build.sh github.com/litmuschaos/chaos-operator/cmd/manager
 
 .PHONY: test
 test:
@@ -82,7 +82,7 @@ dockerops:
 	@echo "------------------"
 	@echo "--> Build & Push chaos-operator docker image"
 	@echo "------------------"
-	sudo docker build . -f build/Dockerfile -t $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG)
+	sudo docker buildx build --file build/Dockerfile --progress plane --platform linux/arm64,linux/amd64 --tag $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .
 	REPONAME=$(DOCKER_REPO) IMGNAME=$(DOCKER_IMAGE) IMGTAG=$(DOCKER_TAG) ./buildscripts/push
 
 unused-package-check:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,13 @@
-FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
+FROM golang:1.14.2
+
+ARG TARGETARCH
 
 ENV OPERATOR=/usr/local/bin/chaos-operator \
     USER_UID=1001 \
     USER_NAME=chaos-operator
 
 # install operator binary
-COPY build/_output/bin/chaos-operator ${OPERATOR}
+COPY build/_output/bin/chaos-operator${TARGETARCH} ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/build/go-multiarch-build.sh
+++ b/build/go-multiarch-build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+package=$1
+if [[ -z "$package" ]]; then
+  echo "usage: $0 <package-name>"
+  exit 1
+fi
+
+package_split=(${package//\// })
+package_name=${package_split[-1]}
+
+# add the arch for which we want to build the image
+platforms=("linux/amd64" "linux/arm64")
+
+for platform in "${platforms[@]}"
+do
+    platform_split=(${platform//\// })
+    GOOS=${platform_split[0]}
+    GOARCH=${platform_split[1]}
+    output_name=build/_output/bin/chaos-operator$GOARCH
+
+    # The script executes for the argument passed (in package variable)
+    # here the arg will be "github.com/litmuschaos/chaos-operator/cmd/manager" for creating binary
+    env GOOS=$GOOS GOARCH=$GOARCH go build -o $output_name $package
+
+    if [ $? -ne 0 ]; then
+        echo 'An error has occurred! Aborting the script execution...'
+        exit 1
+    fi
+done
+

--- a/buildscripts/push
+++ b/buildscripts/push
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-# Push CI images
-function push_ci_image(){
+# Push dev images
+function push_dev_image(){
 
   echo "Pushing ${REPONAME}/${IMGNAME}:${IMGTAG} ..."
   docker push ${REPONAME}/${IMGNAME}:${IMGTAG}
@@ -19,10 +19,10 @@ function push_release_image(){
     # set the release tag in env CIRCLE_TAG
     echo "Pushing ${REPONAME}/${IMGNAME}:${CIRCLE_TAG} ..."
     docker tag ${IMAGEID} ${REPONAME}/${IMGNAME}:${CIRCLE_TAG}
-    docker push ${REPONAME}/${IMGNAME}:${CIRCLE_TAG}
+    docker buildx build --file build/Dockerfile --progress plane --push --platform linux/arm64,linux/amd64 --tag ${REPONAME}/${IMGNAME}:${CIRCLE_TAG} .    
     echo "Pushing ${REPONAME}/${IMGNAME}:latest ..."
     docker tag ${IMAGEID} ${REPONAME}/${IMGNAME}:latest
-    docker push ${REPONAME}/${IMGNAME}:latest
+    docker buildx build --file build/Dockerfile --progress plane --push --platform linux/arm64,linux/amd64 --tag ${REPONAME}/${IMGNAME}:latest .    
   fi;
 
 }
@@ -42,8 +42,8 @@ if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
 then
   docker login -u "${DNAME}" -p "${DPASS}";
   build_type=$(echo $1 | cut -d "=" -f 2)
-  if [ "${build_type}" == "ci" ]; then
-    push_ci_image;
+  if [ "${build_type}" == "dev" ]; then
+    push_dev_image;
   elif [ "${build_type}" == "release" ]; then
     push_release_image; 
   else


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR is for the addition of multi-arch support for chaos-operator image. The current support for `amd64` and `arm64` is added and we can easily add more platform using the go-multiarch-build.sh script.
- circle-ci is also modified to setup `buildx`  which is used to create multi-arch image.

**Which issue this PR fixes** 
-  fixes: litmuschaos/litmus#1550

**Special notes for your reviewer**:

**Checklist:**
-   [X] Fixes #litmuschaos/litmus#1550
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests