### PR TITLE
chore(permission): Adds minimum permission for operator

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -18,9 +18,12 @@ metadata:
   labels:
     name: litmus
 rules:
-- apiGroups: ["","apps","batch","litmuschaos.io","apps.openshift.io"]
-  resources: ["pods","jobs","deployments","replicationcontrollers","replicasets","daemonsets","statefulsets","deploymentconfigs","events","configmaps","services","secrets","chaosengines","chaosexperiments","chaosresults"]
-  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
+- apiGroups: ["","apps","batch","apps.openshift.io"]
+  resources: ["jobs","deployments","replicationcontrollers","daemonsets","replicasets","statefulsets","deploymentconfigs","secrets"]
+  verbs: ["get","list","watch","deletecollection"]
+- apiGroups: ["","litmuschaos.io"]
+  resources: ["pods","configmaps","events","services","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]  
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/tests/manifest/pod_delete_rbac.yaml
+++ b/tests/manifest/pod_delete_rbac.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-delete-sa
+  namespace: litmus
+  labels:
+    name: pod-delete-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: pod-delete-sa
+  namespace: litmus
+  labels:
+    name: pod-delete-sa
+rules:
+- apiGroups: ["","litmuschaos.io","batch","apps"]
+  resources: ["pods","deployments","pods/log","events","jobs","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: pod-delete-sa
+  namespace: litmus
+  labels:
+    name: pod-delete-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-delete-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-delete-sa
+  namespace: litmus


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>


**What this PR does / why we need it**:

- This PR adds minimum permission to run chaosoperator
- An [e2e pipeline](https://gitlab.mayadata.io/litmuschaos/litmus-e2e/pipelines/12749) run with the given permission. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests