### PR TITLE
chore(appinfo): Add ability to provide appinfo as optional

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -46,10 +46,10 @@ spec:
               properties:
                 appkind:
                   type: string
-                  pattern: ^(deployment|statefulset|daemonset|deploymentconfig)$
+                  pattern: ^(^$|deployment|statefulset|daemonset|deploymentconfig)$
                 applabel:
                   type: string
-                  pattern: ([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)
+                  pattern: (([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)|^$)
                 appns:
                   type: string
             auxiliaryAppInfo:

--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -45,9 +45,9 @@ spec:
               properties:
                 appkind:
                   type: string
-                  pattern: ^(deployment|statefulset|daemonset|deploymentconfig)$
+                  pattern: ^(^$|deployment|statefulset|daemonset|deploymentconfig)$
                 applabel:
-                  pattern: ([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)
+                  pattern: (([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)|^$)
                   type: string
                 appns:
                   type: string

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -27,7 +27,7 @@ import (
 // to create a chaos profile
 type ChaosEngineSpec struct {
 	//Appinfo contains deployment details of AUT
-	Appinfo ApplicationParams `json:"appinfo"`
+	Appinfo ApplicationParams `json:"appinfo,omitempty"`
 	//AnnotationCheck defines whether annotation check is allowed or not. It can be true or false
 	AnnotationCheck string `json:"annotationCheck,omitempty"`
 	//ChaosServiceAccount is the SvcAcc specified for chaos runner pods
@@ -112,11 +112,11 @@ type ChaosEngineStatus struct {
 // Controller expects AUT to be annotated with litmuschaos.io/chaos: "true" to run chaos
 type ApplicationParams struct {
 	//Namespace of the AUT
-	Appns string `json:"appns"`
+	Appns string `json:"appns,omitempty"`
 	//Unique label of the AUT
-	Applabel string `json:"applabel"`
+	Applabel string `json:"applabel,omitempty"`
 	//kind of application
-	AppKind string `json:"appkind"`
+	AppKind string `json:"appkind,omitempty"`
 }
 
 // ComponentParams defines information about the runner


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding the ability to provide appinfo as optional field in chaosengine.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests