### PR TITLE
chore(resourceRequirements): Adding resource requirements in chaos pod

### DIFF
--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -262,13 +262,14 @@ type RunProperty struct {
 
 // ExperimentComponents contains ENV, Configmaps and Secrets
 type ExperimentComponents struct {
-	ENV                   []ExperimentENV    `json:"env,omitempty"`
-	ConfigMaps            []ConfigMap        `json:"configMaps,omitempty"`
-	Secrets               []Secret           `json:"secrets,omitempty"`
-	ExperimentAnnotations map[string]string  `json:"experimentannotation,omitempty"`
-	ExperimentImage       string             `json:"experimentImage,omitempty"`
-	NodeSelector          map[string]string  `json:"nodeSelector,omitempty"`
-	StatusCheckTimeouts   StatusCheckTimeout `json:"statusCheckTimeouts,omitempty"`
+	ENV                   []ExperimentENV             `json:"env,omitempty"`
+	ConfigMaps            []ConfigMap                 `json:"configMaps,omitempty"`
+	Secrets               []Secret                    `json:"secrets,omitempty"`
+	ExperimentAnnotations map[string]string           `json:"experimentannotation,omitempty"`
+	ExperimentImage       string                      `json:"experimentImage,omitempty"`
+	NodeSelector          map[string]string           `json:"nodeSelector,omitempty"`
+	StatusCheckTimeouts   StatusCheckTimeout          `json:"statusCheckTimeouts,omitempty"`
+	Resources             corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // StatusCheckTimeout contains Delay and timeouts for the status checks

--- a/pkg/apis/litmuschaos/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/litmuschaos/v1alpha1/zz_generated.deepcopy.go
@@ -486,6 +486,7 @@ func (in *ExperimentComponents) DeepCopyInto(out *ExperimentComponents) {
 		}
 	}
 	out.StatusCheckTimeouts = in.StatusCheckTimeouts
+	in.Resources.DeepCopyInto(&out.Resources)
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding an ability to provide resource requirements for the chaos pod via chaosengine.

### sample engine

```yaml
apiVersion: litmuschaos.io/v1alpha1
kind: ChaosEngine
metadata:
  name: engine
spec:
  engineStatus: "active"
  annotationCheck: "false"
  appinfo:
    applabel: "run=nginx"
    appns: "shubham"
  components:
    runner:
      image: "shubh214/chaos-runner:ci"
      imagePullPolicy: "Always"
  jobCleanUpPolicy: 'retain'
  chaosServiceAccount: litmus
  monitoring: false
  experiments:
    - name: pod-network-loss
      spec:
        components:
          resources:
            requests:
              cpu: 10m
              memory: 100Mi 
            limits:
              cpu: 10m
              memory: 100Mi
          env:
          - name: SEQUENCE
            value: "parallel"

```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests