### PR TITLE
(enhancement)runner: add standard kubernetes labels to chaos-runner

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,11 +2,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/name: litmus-chaos
-    app.kubernetes.io/instance:	litmus-chaos-operator
+    app.kubernetes.io/name: litmus
+    # provide unique instance-id if applicable
+    # app.kubernetes.io/instance: litmus-abcxzy
     app.kubernetes.io/version: v1.8.2
     app.kubernetes.io/component: operator
-    app.kubernetes.io/part-of: litmus-chaos
+    app.kubernetes.io/part-of: litmus
     app.kubernetes.io/managed-by: kubectl
     name: litmus
   name: litmus
@@ -19,11 +20,12 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: litmus-chaos
-        app.kubernetes.io/instance:	litmus-chaos-operator
+        app.kubernetes.io/name: litmus
+        # provide unique instance-id if applicable
+        # app.kubernetes.io/instance: litmus-abcxzy
         app.kubernetes.io/version: v1.8.2
         app.kubernetes.io/component: operator
-        app.kubernetes.io/part-of: litmus-chaos
+        app.kubernetes.io/part-of: litmus
         app.kubernetes.io/managed-by: kubectl
         name: chaos-operator
     spec:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -9,11 +9,12 @@ metadata:
   name: litmus
   namespace: litmus
   labels:
-    app.kubernetes.io/name: litmus-chaos
-    app.kubernetes.io/instance:	litmus-chaos-operator
+    app.kubernetes.io/name: litmus
+    # provide unique instance-id if applicable
+    # app.kubernetes.io/instance: litmus-abcxzy
     app.kubernetes.io/version: v1.8.2
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/part-of: litmus-chaos
+    app.kubernetes.io/component: operator-serviceaccount
+    app.kubernetes.io/part-of: litmus
     app.kubernetes.io/managed-by: kubectl
     name: litmus
 ---
@@ -22,11 +23,12 @@ kind: ClusterRole
 metadata:
   name: litmus
   labels:
-    app.kubernetes.io/name: litmus-chaos
-    app.kubernetes.io/instance:	litmus-chaos-operator
+    app.kubernetes.io/name: litmus
+    # provide unique instance-id if applicable
+    # app.kubernetes.io/instance: litmus-abcxzy
     app.kubernetes.io/version: v1.8.2
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/part-of: litmus-chaos
+    app.kubernetes.io/component: operator-clusterrole
+    app.kubernetes.io/part-of: litmus
     app.kubernetes.io/managed-by: kubectl
     name: litmus
 rules:
@@ -42,11 +44,12 @@ kind: ClusterRoleBinding
 metadata:
   name: litmus
   labels:
-    app.kubernetes.io/name: litmus-chaos
-    app.kubernetes.io/instance:	litmus-chaos-operator
+    app.kubernetes.io/name: litmus
+    # provide unique instance-id if applicable
+    # app.kubernetes.io/instance: litmus-abcxzy
     app.kubernetes.io/version: v1.8.2
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/part-of: litmus-chaos
+    app.kubernetes.io/component: operator-clusterrolebinding
+    app.kubernetes.io/part-of: litmus
     app.kubernetes.io/managed-by: kubectl
     name: litmus
 roleRef:

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -217,6 +217,17 @@ func getChaosRunnerENV(cr *litmuschaosv1alpha1.ChaosEngine, aExList []string, Cl
 	}
 }
 
+// getChaosRunnerLabels return the labels required for chaos-runner
+func getChaosRunnerLabels(cr *litmuschaosv1alpha1.ChaosEngine) map[string]string {
+	return map[string]string{
+		"app": cr.Name,
+        "chaosUID": string(cr.UID),
+		"app.kubernetes.io/component": "chaos-runner",
+        "app.kubernetes.io/part-of": "litmus",
+	}
+}
+
+
 // newGoRunnerPodForCR defines a new go-based Runner Pod
 func newGoRunnerPodForCR(engine *chaosTypes.EngineInfo) (*corev1.Pod, error) {
 	containerForRunner := container.NewBuilder().
@@ -241,7 +252,7 @@ func newGoRunnerPodForCR(engine *chaosTypes.EngineInfo) (*corev1.Pod, error) {
 		WithName(engine.Instance.Name + "-runner").
 		WithNamespace(engine.Instance.Namespace).
 		WithAnnotations(engine.Instance.Spec.Components.Runner.RunnerAnnotation).
-		WithLabels(map[string]string{"app": engine.Instance.Name, "chaosUID": string(engine.Instance.UID)}).
+		WithLabels(getChaosRunnerLabels(engine.Instance)).
 		WithServiceAccountName(engine.Instance.Spec.ChaosServiceAccount).
 		WithRestartPolicy("OnFailure").
 		WithContainerBuilder(containerForRunner)


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adds standard, recommended Kubernetes labels to the chaos-runner 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests