### PR TITLE
chore(app_kind): Pass app kind information to experiment

### DIFF
--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -191,6 +191,10 @@ func getChaosRunnerENV(cr *litmuschaosv1alpha1.ChaosEngine, aExList []string, Cl
 			Value: cr.Spec.Appinfo.Applabel,
 		},
 		{
+			Name:  "APP_KIND",
+			Value: cr.Spec.Appinfo.AppKind,
+		},
+		{
 			Name:  "APP_NAMESPACE",
 			Value: appNS,
 		},

--- a/pkg/controller/chaosengine/chaosengine_controller_test.go
+++ b/pkg/controller/chaosengine/chaosengine_controller_test.go
@@ -86,6 +86,7 @@ func TestGetChaosRunnerENV(t *testing.T) {
 	fakeNameSpace := "Fake NameSpace"
 	fakeServiceAcc := "Fake Service Account"
 	fakeAppLabel := "Fake Label"
+	fakeAppKind := "Fake Kind"
 	fakeAExList := []string{"fake string"}
 	fakeAuxilaryAppInfo := "ns1:name=percona,ns2:run=nginx"
 	fakeClientUUID := "12345678-9012-3456-7890-123456789012"
@@ -106,6 +107,7 @@ func TestGetChaosRunnerENV(t *testing.T) {
 					Appinfo: litmuschaosv1alpha1.ApplicationParams{
 						Applabel: fakeAppLabel,
 						Appns:    fakeNameSpace,
+						AppKind:  fakeAppKind,
 					},
 					AuxiliaryAppInfo: fakeAuxilaryAppInfo,
 				},
@@ -119,6 +121,10 @@ func TestGetChaosRunnerENV(t *testing.T) {
 				{
 					Name:  "APP_LABEL",
 					Value: fakeAppLabel,
+				},
+				{
+					Name:  "APP_KIND",
+					Value: fakeAppKind,
 				},
 				{
 					Name:  "APP_NAMESPACE",
@@ -151,8 +157,8 @@ func TestGetChaosRunnerENV(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actualResult := getChaosRunnerENV(mock.instance, mock.aExList, fakeClientUUID)
 			println(actualResult)
-			if len(actualResult) != 8 {
-				t.Fatalf("Test %q failed: expected array length to be 8", name)
+			if len(actualResult) != 9 {
+				t.Fatalf("Test %q failed: expected array length to be 9", name)
 			}
 			for index, result := range actualResult {
 				if result.Value != mock.expectedResult[index].Value {


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

**What this PR does / why we need it**:

- This is for passing app kind information to chaos experiment. We pass app labe and app namespace but app kind was missing ENV. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests