### PR TITLE
fix(analytics): Skip the clientUUID generation if ANALYTICS is set to False

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -49,8 +49,8 @@ func TriggerAnalytics() error {
 		return fmt.Errorf("new client generation failed, error : %s", err)
 	}
 
-	if !(ClientUUID != "") {
-		return fmt.Errorf("uuid generation failed, error: %s", err)
+	if ClientUUID == "" {
+		return fmt.Errorf("uuid generation failed")
 	}
 	client.ClientID(ClientUUID)
 	err = client.Send(ga.NewEvent(category, action).Label(label))

--- a/pkg/analytics/uuid.go
+++ b/pkg/analytics/uuid.go
@@ -26,7 +26,7 @@ import (
 // UUIDGenerator creates a new UUID each time a new user triggers an event
 func UUIDGenerator() string {
 	uuid := ""
-	if strings.ToUpper(os.Getenv("ANALYTICS")) == "TRUE" {
+	if strings.ToUpper(os.Getenv("ANALYTICS")) != "FALSE" {
 		b := make([]byte, 16)
 		_, err := rand.Read(b)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- We are only setting this flag when we want to disable analytics. If the analytics is allowed then `ANALYTICS` flag is unset instead of setting `TRUE` value that's why changing this condition to match with `FALSE` instead of True value.

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests