### PR TITLE
(enhancement)resources: add argo rollouts as a supported parent resource for chaos

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -46,7 +46,7 @@ spec:
               properties:
                 appkind:
                   type: string
-                  pattern: ^(^$|deployment|statefulset|daemonset|deploymentconfig)$
+                  pattern: ^(^$|deployment|statefulset|daemonset|deploymentconfig|rollout)$
                 applabel:
                   type: string
                   pattern: (([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)|^$)

--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -45,7 +45,7 @@ spec:
               properties:
                 appkind:
                   type: string
-                  pattern: ^(^$|deployment|statefulset|daemonset|deploymentconfig)$
+                  pattern: ^(^$|deployment|statefulset|daemonset|deploymentconfig|rollout)$
                 applabel:
                   pattern: (([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)|^$)
                   type: string

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -32,8 +32,8 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
     name: litmus
 rules:
-- apiGroups: ["","apps","batch","apps.openshift.io"]
-  resources: ["jobs","deployments","replicationcontrollers","daemonsets","replicasets","statefulsets","deploymentconfigs","secrets"]
+- apiGroups: ["","apps","batch","apps.openshift.io","argoproj.io"]
+  resources: ["jobs","deployments","replicationcontrollers","daemonsets","replicasets","statefulsets","deploymentconfigs","rollouts","secrets"]
   verbs: ["get","list","watch","deletecollection"]
 - apiGroups: ["","litmuschaos.io"]
   resources: ["pods","configmaps","events","services","chaosengines","chaosexperiments","chaosresults"]

--- a/pkg/controller/resource/argorollouts.go
+++ b/pkg/controller/resource/argorollouts.go
@@ -44,12 +44,13 @@ func getRolloutList(clientSet dynamic.Interface, engine *chaosTypes.EngineInfo) 
 
 	dynamicClient := clientSet.Resource(gvrro)
 
-	rolloutList, err := dynamicClient.List(metav1.ListOptions{})
+	rolloutList, err := dynamicClient.Namespace(engine.AppInfo.Namespace).List(metav1.ListOptions{
+			LabelSelector: engine.Instance.Spec.Appinfo.Applabel})
 	if err != nil {
-		return nil, fmt.Errorf("error while listing argo rollouts")
+		return nil, fmt.Errorf("error while listing argo rollouts with matching labels %s", engine.Instance.Spec.Appinfo.Applabel)
 	}
 	if len(rolloutList.Items) == 0 {
-		return nil, fmt.Errorf("no argo rollouts found")
+		return nil, fmt.Errorf("no argo rollouts with matching labels %s", engine.Instance.Spec.Appinfo.Applabel)
 	}
 	return rolloutList, err
 }

--- a/pkg/controller/resource/argorollouts.go
+++ b/pkg/controller/resource/argorollouts.go
@@ -40,6 +40,7 @@ func CheckRolloutAnnotation(clientSet dynamic.Interface, engine *chaosTypes.Engi
 	return engine, nil
 }
 
+// getRolloutList returns a list of argo rollout resources that are found in the app namespace with specified label
 func getRolloutList(clientSet dynamic.Interface, engine *chaosTypes.EngineInfo) (*unstructured.UnstructuredList, error) {
 
 	dynamicClient := clientSet.Resource(gvrro)
@@ -55,7 +56,7 @@ func getRolloutList(clientSet dynamic.Interface, engine *chaosTypes.EngineInfo) 
 	return rolloutList, err
 }
 
-// This will check and count the total chaos enabled application
+// checkForChaosEnabledRollout  will check and count the total chaos enabled application
 func checkForChaosEnabledRollout(rolloutList *unstructured.UnstructuredList, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 
 	chaosEnabledRollout := 0

--- a/pkg/controller/resource/argorollouts.go
+++ b/pkg/controller/resource/argorollouts.go
@@ -1,0 +1,71 @@
+package resource
+
+import (
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	chaosTypes "github.com/litmuschaos/chaos-operator/pkg/controller/types"
+)
+
+var (
+	gvrro = schema.GroupVersionResource{
+		Group:    "argoproj.io",
+		Version:  "v1alpha1",
+		Resource: "rollouts",
+	}
+)
+
+// CheckRolloutAnnotation will check the annotation of argo rollout 
+func CheckRolloutAnnotation(clientSet dynamic.Interface, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, error) {
+
+	rolloutList, err := getRolloutList(clientSet, engine)
+	if err != nil {
+		return engine, err
+	}
+	engine, chaosEnabledRollout, err := checkForChaosEnabledRollout(rolloutList, engine)
+	if err != nil {
+		return engine, err
+	}
+
+	if chaosEnabledRollout == 0 {
+		return engine, errors.New("no argo rollout chaos-candidate found")
+	}
+	chaosTypes.Log.Info("argo rollout chaos candidate:", "appName: ", engine.AppName, " appUUID: ", engine.AppUUID)
+
+	return engine, nil
+}
+
+func getRolloutList(clientSet dynamic.Interface, engine *chaosTypes.EngineInfo) (*unstructured.UnstructuredList, error) {
+
+	dynamicClient := clientSet.Resource(gvrro)
+
+	rolloutList, err := dynamicClient.List(metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error while listing argo rollouts")
+	}
+	if len(rolloutList.Items) == 0 {
+		return nil, fmt.Errorf("no argo rollouts found")
+	}
+	return rolloutList, err
+}
+
+// This will check and count the total chaos enabled application
+func checkForChaosEnabledRollout(rolloutList *unstructured.UnstructuredList, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
+
+	chaosEnabledRollout := 0
+	for _, rollout := range rolloutList.Items {
+		engine.AppName = rollout.GetName()
+		engine.AppUUID = rollout.GetUID()
+		annotationValue := rollout.GetAnnotations()[ChaosAnnotationKey]
+		chaosEnabledRollout = CountTotalChaosEnabled(annotationValue, chaosEnabledRollout)
+		if chaosEnabledRollout > 1 {
+			return engine, chaosEnabledRollout, errors.New("too many argo rollouts with specified label are annotated for chaos, either provide unique labels or annotate only desired rollout for chaos")
+		}
+	}
+	return engine, chaosEnabledRollout, nil
+}

--- a/pkg/controller/resource/daemonset.go
+++ b/pkg/controller/resource/daemonset.go
@@ -57,7 +57,7 @@ func getDaemonSetLists(clientset kubernetes.Interface, engine *chaosTypes.Engine
 	return targetAppList, err
 }
 
-// This will check and count the total chaos enabled application
+// checkForChaosEnabledDaemonSet will check and count the total chaos enabled application
 func checkForChaosEnabledDaemonSet(targetAppList *appsV1.DaemonSetList, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledDaemonSet := 0
 	for _, daemonSet := range targetAppList.Items {

--- a/pkg/controller/resource/deployment.go
+++ b/pkg/controller/resource/deployment.go
@@ -58,7 +58,7 @@ func getDeploymentLists(clientset kubernetes.Interface, engine *chaosTypes.Engin
 	return targetAppList, err
 }
 
-// This will check and count the total chaos enabled application
+// checkForChaosEnabledDeployment will check and count the total chaos enabled application
 func checkForChaosEnabledDeployment(targetAppList *v1.DeploymentList, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledDeployment := 0
 	for _, deployment := range targetAppList.Items {

--- a/pkg/controller/resource/deploymentconfig.go
+++ b/pkg/controller/resource/deploymentconfig.go
@@ -44,12 +44,13 @@ func getDeploymentConfigList(clientSet dynamic.Interface, engine *chaosTypes.Eng
 
 	dynamicClient := clientSet.Resource(gvrdc)
 
-	deploymentConfigList, err := dynamicClient.List(metav1.ListOptions{})
+	deploymentConfigList, err := dynamicClient.Namespace(engine.AppInfo.Namespace).List(metav1.ListOptions{
+			LabelSelector: engine.Instance.Spec.Appinfo.Applabel})
 	if err != nil {
-		return nil, fmt.Errorf("error while listing deploymentconfigs")
+		return nil, fmt.Errorf("error while listing deploymentconfigs with matching labels %s", engine.Instance.Spec.Appinfo.Applabel)
 	}
 	if len(deploymentConfigList.Items) == 0 {
-		return nil, fmt.Errorf("no deploymentconfigs found")
+		return nil, fmt.Errorf("no deploymentconfigs with matching labels %s", engine.Instance.Spec.Appinfo.Applabel)
 	}
 	return deploymentConfigList, err
 }

--- a/pkg/controller/resource/deploymentconfig.go
+++ b/pkg/controller/resource/deploymentconfig.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	gvr = schema.GroupVersionResource{
+	gvrdc = schema.GroupVersionResource{
 		Group:    "apps.openshift.io",
 		Version:  "v1",
 		Resource: "deploymentconfigs",
@@ -42,14 +42,14 @@ func CheckDeploymentConfigAnnotation(clientSet dynamic.Interface, engine *chaosT
 
 func getDeploymentConfigList(clientSet dynamic.Interface, engine *chaosTypes.EngineInfo) (*unstructured.UnstructuredList, error) {
 
-	dynamicClient := clientSet.Resource(gvr)
+	dynamicClient := clientSet.Resource(gvrdc)
 
 	deploymentConfigList, err := dynamicClient.List(metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error while listing deploymentconfigs with matching labels %s", engine.Instance.Spec.Appinfo.Applabel)
+		return nil, fmt.Errorf("error while listing deploymentconfigs")
 	}
 	if len(deploymentConfigList.Items) == 0 {
-		return nil, fmt.Errorf("no deploymentconfigs with matching labels %s", engine.Instance.Spec.Appinfo.Applabel)
+		return nil, fmt.Errorf("no deploymentconfigs found")
 	}
 	return deploymentConfigList, err
 }

--- a/pkg/controller/resource/deploymentconfig.go
+++ b/pkg/controller/resource/deploymentconfig.go
@@ -55,7 +55,7 @@ func getDeploymentConfigList(clientSet dynamic.Interface, engine *chaosTypes.Eng
 	return deploymentConfigList, err
 }
 
-// This will check and count the total chaos enabled application
+// checkForChaosEnabledDeploymentConfig will check and count the total chaos enabled application
 func checkForChaosEnabledDeploymentConfig(deploymentConfigList *unstructured.UnstructuredList, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 
 	chaosEnabledDeploymentConfig := 0

--- a/pkg/controller/resource/resource.go
+++ b/pkg/controller/resource/resource.go
@@ -72,6 +72,11 @@ func CheckChaosAnnotation(engine *chaosTypes.EngineInfo, clientset kubernetes.In
 		if err != nil {
 			return engine, fmt.Errorf("resource type 'deploymentconfig', err: %+v", err)
 		}
+	case "rollout", "rollouts":
+		engine, err := CheckRolloutAnnotation(dynamicClientSet, engine)
+		if err != nil {
+			return engine, fmt.Errorf("resource type 'rollout', err: %+v", err)
+		}
 	default:
 		return engine, fmt.Errorf("resource type '%s' not supported for induce chaos", engine.AppInfo.Kind)
 	}

--- a/pkg/controller/resource/statefulset.go
+++ b/pkg/controller/resource/statefulset.go
@@ -58,7 +58,7 @@ func getStatefulSetLists(clientset kubernetes.Interface, engine *chaosTypes.Engi
 	return targetAppList, err
 }
 
-// This will check and count the total chaos enabled application
+// checkForChaosEnabledStatefulSet will check and count the total chaos enabled application
 func checkForChaosEnabledStatefulSet(targetAppList *appsV1.StatefulSetList, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledStatefulSet := 0
 	for _, statefulSet := range targetAppList.Items {


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Supports chaos on [argo rollouts](https://argoproj.github.io/argo-rollouts/) resource to facilitate chaos as a step in blue-green/canary deployments
- Also fixes a bug in the deploymentconfig list function in resource pkg

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests