### PR TITLE
(fix)reconcile: fix incorrect sequence of events for engine restart

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -55,7 +55,7 @@ spec:
               type: string
             engineState:
               type: string
-              pattern: ^(active|stop|initialized|stopped)$
+              pattern: ^(active|stop)$
             chaosServiceAccount:
               type: string
             components:

--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -54,7 +54,7 @@ spec:
               type: string
             engineState:
               type: string
-              pattern: ^(active|stop|initialized|stopped)$
+              pattern: ^(active|stop)$
             chaosServiceAccount:
               type: string
             components:


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR fixes the following issues in the reconcile flow of the chaos operator: 

- Creating a **new** chaosengine resource with `.spec.engineState` set to `stop` (this is a model being used by some users to *pre-install* the engine as part of a package, with experiments being triggered when needed via a patch to state: active) causes the reconciler to patch the `.status.engineStatus` to `stopped`. This is undesirable. Having it set to stopped causes a subsequent patch to engineState: active to be considered as a "Restart" (post abort or completion) which generates both the `RestartInProgress` as well as a "ChaosEngineInitialized" events.

  The fix causes the status in such a case to remain empty/unset. 

- The ChaosEngineInitialized event is seen to be generated only for new engine creation and a restart post **abort**. It isn't generated for the restart post graceful **completion**.  Also, the event message incorrectly states that the runner is created successfully although the function to create it is invoked later. 

  The fix involves the removal of finalizer upon graceful completion of chaos also, much in the same way as a forceful abort. 
  This is done in-spite of the jobCleanupPolicy as the child resources by this time are not "live" and are already completed. 

- The ChaosEngineInitialized event message incorrectly states that the runner is created successfully although the function to create it is invoked later. Also, this event is generated even before setting the finalizer - which is the actual indicator of start of chaos resource creation. 

  As part of this fix, the generation of the ChaosEngineInitialization event is generated after the finalizer is applied. The event message has been fixed to state what the initialization steps are - i.e., filtering the AUT & launching chaos runner.   



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests