### PR TITLE
Add `type` definition to ChaosExperiment CRD hostFileVolumes object

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -594,6 +594,8 @@ spec:
                       nodePath:
                         type: string
                         minLength: 1
+                      type:
+                        type: string
                 securityContext:
                   type: object
                 hostPID:

--- a/deploy/crds/chaosexperiment_crd.yaml
+++ b/deploy/crds/chaosexperiment_crd.yaml
@@ -227,6 +227,8 @@ spec:
                       nodePath:
                         type: string
                         minLength: 1
+                      type:
+                        type: string
                 securityContext:
                   type: object
                 hostPID:

--- a/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
@@ -57,6 +57,7 @@ type HostFile struct {
 	Name      string `json:"name"`
 	MountPath string `json:"mountPath"`
 	NodePath  string `json:"nodePath"`
+	Type      corev1.HostPathType `json:"type,omitempty"`
 }
 
 // ExperimentDef defines information about nature of chaos & components subjected to it


### PR DESCRIPTION
Add a `type` field to the `hostFileVolumes` object on ChaosExperiments, to enable specifying different types when mounting hostPaths, such as CRI sockets

litmuschaos/litmus#2410 depends on this PR

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests