### PR TITLE
feat(annotation): Enable the multiple app with annotation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,10 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:H
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/ant31/crd-validation v0.0.0-20180702145049-30f8a35d0ac2/go.mod h1:X0noFIik9YqfhGYBLEHg8LJKEwy7QIitLQuFMpKLcPk=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
@@ -858,6 +860,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/controller/chaosengine/chaosengine_controller_test.go
+++ b/pkg/controller/chaosengine/chaosengine_controller_test.go
@@ -248,7 +248,7 @@ func TestGetAnnotationCheck(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: false,
@@ -274,7 +274,7 @@ func TestGetAnnotationCheck(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -302,7 +302,6 @@ func TestGetAnnotationCheck(t *testing.T) {
 					},
 				},
 
-				AppUUID:        "fake_id",
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: true,
@@ -354,7 +353,7 @@ func TestValidateAnnontatedApplication(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -416,8 +415,7 @@ func TestValidateAnnontatedApplication(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
-				AppName:        "fake_app",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: true,
@@ -662,7 +660,7 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: false,
@@ -689,7 +687,7 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -718,7 +716,7 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -747,7 +745,7 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -758,7 +756,6 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 				Instance: &litmuschaosv1alpha1.ChaosEngine{
 					ObjectMeta: metav1.ObjectMeta{},
 				},
-				AppUUID:        "fake_id",
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: true,
@@ -774,7 +771,7 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 						ChaosServiceAccount: "fake-serviceAccount",
 					},
 				},
-				AppUUID:        "",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: true,
@@ -790,7 +787,7 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 						ChaosServiceAccount: "fake-serviceAccount",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{},
 			},
 			isErr: true,
@@ -811,7 +808,7 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{},
 			},
 			isErr: true,
@@ -1296,7 +1293,7 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: false,
@@ -1318,7 +1315,7 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -1342,7 +1339,7 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -1366,7 +1363,7 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -1377,7 +1374,7 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 				Instance: &litmuschaosv1alpha1.ChaosEngine{
 					ObjectMeta: metav1.ObjectMeta{},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: true,
@@ -1393,7 +1390,7 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 						ChaosServiceAccount: "fake-serviceAccount",
 					},
 				},
-				AppUUID:        "",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: true,
@@ -1409,7 +1406,7 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 						ChaosServiceAccount: "fake-serviceAccount",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{},
 			},
 			isErr: true,
@@ -1430,7 +1427,7 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{},
 			},
 			isErr: true,
@@ -1769,7 +1766,7 @@ func TestReconcileForCreationAndRunning(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: false,
@@ -1796,7 +1793,6 @@ func TestReconcileForCreationAndRunning(t *testing.T) {
 					},
 				},
 
-				AppUUID:        "fake_id",
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: true,
@@ -1822,7 +1818,7 @@ func TestReconcileForCreationAndRunning(t *testing.T) {
 						},
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			isErr: true,

--- a/pkg/controller/resource/argorollouts.go
+++ b/pkg/controller/resource/argorollouts.go
@@ -35,7 +35,6 @@ func CheckRolloutAnnotation(clientSet dynamic.Interface, engine *chaosTypes.Engi
 	if chaosEnabledRollout == 0 {
 		return engine, errors.New("no argo rollout chaos-candidate found")
 	}
-	chaosTypes.Log.Info("argo rollout chaos candidate:", "appName: ", engine.AppName, " appUUID: ", engine.AppUUID)
 
 	return engine, nil
 }
@@ -61,12 +60,10 @@ func checkForChaosEnabledRollout(rolloutList *unstructured.UnstructuredList, eng
 
 	chaosEnabledRollout := 0
 	for _, rollout := range rolloutList.Items {
-		engine.AppName = rollout.GetName()
-		engine.AppUUID = rollout.GetUID()
 		annotationValue := rollout.GetAnnotations()[ChaosAnnotationKey]
-		chaosEnabledRollout = CountTotalChaosEnabled(annotationValue, chaosEnabledRollout)
-		if chaosEnabledRollout > 1 {
-			return engine, chaosEnabledRollout, errors.New("too many argo rollouts with specified label are annotated for chaos, either provide unique labels or annotate only desired rollout for chaos")
+		if IsChaosEnabled(annotationValue) {
+			chaosTypes.Log.Info("chaos candidate of", "kind:", engine.AppInfo.Kind, "appName: ", rollout.GetName(), "appUUID: ", rollout.GetUID())
+			chaosEnabledRollout++
 		}
 	}
 	return engine, chaosEnabledRollout, nil

--- a/pkg/controller/resource/daemonset.go
+++ b/pkg/controller/resource/daemonset.go
@@ -61,12 +61,10 @@ func getDaemonSetLists(clientset kubernetes.Interface, engine *chaosTypes.Engine
 func checkForChaosEnabledDaemonSet(targetAppList *appsV1.DaemonSetList, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledDaemonSet := 0
 	for _, daemonSet := range targetAppList.Items {
-		engine.AppName = daemonSet.ObjectMeta.Name
-		engine.AppUUID = daemonSet.ObjectMeta.UID
 		annotationValue := daemonSet.ObjectMeta.GetAnnotations()[ChaosAnnotationKey]
-		chaosEnabledDaemonSet = CountTotalChaosEnabled(annotationValue, chaosEnabledDaemonSet)
-		if chaosEnabledDaemonSet > 1 {
-			return engine, chaosEnabledDaemonSet, errors.New("too many daemonsets with specified label are annotated for chaos, either provide unique labels or annotate only desired app for chaos")
+		if IsChaosEnabled(annotationValue) {
+			chaosTypes.Log.Info("chaos candidate of", "kind:", engine.AppInfo.Kind, "appName: ", daemonSet.ObjectMeta.Name, "appUUID: ", daemonSet.ObjectMeta.UID)
+			chaosEnabledDaemonSet++
 		}
 	}
 	return engine, chaosEnabledDaemonSet, nil

--- a/pkg/controller/resource/deployment.go
+++ b/pkg/controller/resource/deployment.go
@@ -40,7 +40,6 @@ func CheckDeploymentAnnotation(clientset kubernetes.Interface, engine *chaosType
 	if chaosEnabledDeployment == 0 {
 		return engine, errors.New("no chaos-candidate found")
 	}
-	chaosTypes.Log.Info("Deployment chaos candidate:", "appName: ", engine.AppName, " appUUID: ", engine.AppUUID)
 	return engine, nil
 }
 
@@ -62,12 +61,10 @@ func getDeploymentLists(clientset kubernetes.Interface, engine *chaosTypes.Engin
 func checkForChaosEnabledDeployment(targetAppList *v1.DeploymentList, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledDeployment := 0
 	for _, deployment := range targetAppList.Items {
-		engine.AppName = deployment.ObjectMeta.Name
-		engine.AppUUID = deployment.ObjectMeta.UID
 		annotationValue := deployment.ObjectMeta.GetAnnotations()[ChaosAnnotationKey]
-		chaosEnabledDeployment = CountTotalChaosEnabled(annotationValue, chaosEnabledDeployment)
-		if chaosEnabledDeployment > 1 {
-			return engine, chaosEnabledDeployment, errors.New("too many deployments with specified label are annotated for chaos, either provide unique labels or annotate only desired app for chaos")
+		if IsChaosEnabled(annotationValue) {
+			chaosTypes.Log.Info("chaos candidate of", "kind:", engine.AppInfo.Kind, "appName: ", deployment.ObjectMeta.Name, "appUUID: ", deployment.ObjectMeta.UID)
+			chaosEnabledDeployment++
 		}
 	}
 	return engine, chaosEnabledDeployment, nil

--- a/pkg/controller/resource/deploymentconfig.go
+++ b/pkg/controller/resource/deploymentconfig.go
@@ -35,7 +35,6 @@ func CheckDeploymentConfigAnnotation(clientSet dynamic.Interface, engine *chaosT
 	if chaosEnabledDeploymentConfig == 0 {
 		return engine, errors.New("no DeploymentConfig chaos-candidate found")
 	}
-	chaosTypes.Log.Info("DeploymentConfig chaos candidate:", "appName: ", engine.AppName, " appUUID: ", engine.AppUUID)
 
 	return engine, nil
 }
@@ -60,12 +59,10 @@ func checkForChaosEnabledDeploymentConfig(deploymentConfigList *unstructured.Uns
 
 	chaosEnabledDeploymentConfig := 0
 	for _, deploymentconfig := range deploymentConfigList.Items {
-		engine.AppName = deploymentconfig.GetName()
-		engine.AppUUID = deploymentconfig.GetUID()
 		annotationValue := deploymentconfig.GetAnnotations()[ChaosAnnotationKey]
-		chaosEnabledDeploymentConfig = CountTotalChaosEnabled(annotationValue, chaosEnabledDeploymentConfig)
-		if chaosEnabledDeploymentConfig > 1 {
-			return engine, chaosEnabledDeploymentConfig, errors.New("too many deploymentconfig with specified label are annotated for chaos, either provide unique labels or annotate only desired app for chaos")
+		if IsChaosEnabled(annotationValue) {
+			chaosTypes.Log.Info("chaos candidate of", "kind:", engine.AppInfo.Kind, "appName: ", deploymentconfig.GetName(), "appUUID: ", deploymentconfig.GetUID())
+			chaosEnabledDeploymentConfig++
 		}
 	}
 	return engine, chaosEnabledDeploymentConfig, nil

--- a/pkg/controller/resource/resource.go
+++ b/pkg/controller/resource/resource.go
@@ -80,14 +80,10 @@ func CheckChaosAnnotation(engine *chaosTypes.EngineInfo, clientset kubernetes.In
 	default:
 		return engine, fmt.Errorf("resource type '%s' not supported for induce chaos", engine.AppInfo.Kind)
 	}
-	chaosTypes.Log.Info("chaos candidate of", "kind:", engine.AppInfo.Kind, "appName: ", engine.AppName, "appUUID: ", engine.AppUUID)
 	return engine, nil
 }
 
-// CountTotalChaosEnabled will count the number of chaos enabled applications
-func CountTotalChaosEnabled(annotationValue string, chaosCandidates int) int {
-	if annotationValue == ChaosAnnotationValue {
-		chaosCandidates++
-	}
-	return chaosCandidates
+// IsChaosEnabled check for the given annotation value
+func IsChaosEnabled(annotationValue string) bool {
+	return annotationValue == ChaosAnnotationValue
 }

--- a/pkg/controller/resource/resource_test.go
+++ b/pkg/controller/resource/resource_test.go
@@ -93,7 +93,7 @@ func TestCheckChaosAnnotationDeployment(t *testing.T) {
 						"app": "nginx1",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			deployment: []appv1.Deployment{
@@ -154,7 +154,6 @@ func TestCheckChaosAnnotationDeployment(t *testing.T) {
 						"app": "nginx2",
 					},
 				},
-				AppUUID:        "fake_id",
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -362,7 +361,7 @@ func TestCheckChaosAnnotationStatefulSet(t *testing.T) {
 						"app": "nginx1",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			statefulSet: []appv1.StatefulSet{
@@ -423,7 +422,7 @@ func TestCheckChaosAnnotationStatefulSet(t *testing.T) {
 						"app": "nginx2",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -631,7 +630,7 @@ func TestCheckChaosAnnotationDaemonset(t *testing.T) {
 						"app": "nginx1",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			daemonset: []appv1.DaemonSet{
@@ -692,7 +691,7 @@ func TestCheckChaosAnnotationDaemonset(t *testing.T) {
 						"app": "nginx2",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -900,7 +899,7 @@ func TestCheckChaosAnnotationDeploymentConfigs(t *testing.T) {
 						"app": "nginx1",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			deploymentconfig: []unstructured.Unstructured{
@@ -962,7 +961,7 @@ func TestCheckChaosAnnotationDeploymentConfigs(t *testing.T) {
 						"app": "nginx2",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 
@@ -1186,7 +1185,7 @@ func TestCheckChaosAnnotationRollouts(t *testing.T) {
 						"app": "nginx1",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 			rollout: []unstructured.Unstructured{
@@ -1250,7 +1249,7 @@ func TestCheckChaosAnnotationRollouts(t *testing.T) {
 						"app": "nginx2",
 					},
 				},
-				AppUUID:        "fake_id",
+
 				AppExperiments: []string{"exp-1"},
 			},
 

--- a/pkg/controller/resource/statefulset.go
+++ b/pkg/controller/resource/statefulset.go
@@ -40,7 +40,6 @@ func CheckStatefulSetAnnotation(clientset kubernetes.Interface, engine *chaosTyp
 	if chaosEnabledStatefulSet == 0 {
 		return engine, errors.New("no chaos-candidate found")
 	}
-	chaosTypes.Log.Info("Statefulset chaos candidate:", "appName: ", engine.AppName, " appUUID: ", engine.AppUUID)
 	return engine, nil
 }
 
@@ -62,12 +61,10 @@ func getStatefulSetLists(clientset kubernetes.Interface, engine *chaosTypes.Engi
 func checkForChaosEnabledStatefulSet(targetAppList *appsV1.StatefulSetList, engine *chaosTypes.EngineInfo) (*chaosTypes.EngineInfo, int, error) {
 	chaosEnabledStatefulSet := 0
 	for _, statefulSet := range targetAppList.Items {
-		engine.AppName = statefulSet.ObjectMeta.Name
-		engine.AppUUID = statefulSet.ObjectMeta.UID
 		annotationValue := statefulSet.ObjectMeta.GetAnnotations()[ChaosAnnotationKey]
-		chaosEnabledStatefulSet = CountTotalChaosEnabled(annotationValue, chaosEnabledStatefulSet)
-		if chaosEnabledStatefulSet > 1 {
-			return engine, chaosEnabledStatefulSet, errors.New("too many statefulsets with specified label are annotated for chaos, either provide unique labels or annotate only desired app for chaos")
+		if IsChaosEnabled(annotationValue) {
+			chaosTypes.Log.Info("chaos candidate of", "kind:", engine.AppInfo.Kind, "appName: ", statefulSet.ObjectMeta.Name, "appUUID: ", statefulSet.ObjectMeta.UID)
+			chaosEnabledStatefulSet++
 		}
 	}
 	return engine, chaosEnabledStatefulSet, nil

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -32,7 +32,6 @@ limitations under the License.
 package types
 
 import (
-	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
@@ -74,6 +73,4 @@ type EngineInfo struct {
 	Secrets        []v1alpha1.Secret
 	VolumeOpts     utils.VolumeOpts
 	AppExperiments []string
-	AppName        string
-	AppUUID        types.UID
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Earlier Chaos Operator allows only a single annotated application as a chaos candidate if the annotationCheck is set to true. With these changes, it will enable multiple annotated applications to be targeted as chaos candidates.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests