### PR TITLE
fix(crds): Removing maxProperties field from openapi validator for chaosengine

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -153,7 +153,6 @@ spec:
                                 method:
                                   type: object
                                   minProperties: 1
-                                  maxProperties: 1
                                   properties:
                                     get:
                                       type: object

--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -152,7 +152,6 @@ spec:
                                 method:
                                   type: object
                                   minProperties: 1
-                                  maxProperties: 1
                                   properties:
                                     get:
                                       type: object


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Removing maxProperties field from openapi validator for chaosengine CRD

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests