### PR TITLE
Added support for Equality-based and Set-based requirements for App Label

### DIFF
--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -315,11 +315,7 @@ func initializeApplicationInfo(instance *litmuschaosv1alpha1.ChaosEngine, appInf
 	}
 
 	if instance.Spec.Appinfo.Applabel != "" {
-		appLabel := strings.Split(instance.Spec.Appinfo.Applabel, "=")
-		chaosTypes.AppLabelKey = appLabel[0]
-		chaosTypes.AppLabelValue = appLabel[1]
-		appInfo.Label = make(map[string]string)
-		appInfo.Label[chaosTypes.AppLabelKey] = chaosTypes.AppLabelValue
+		appInfo.Label = instance.Spec.Appinfo.Applabel
 	}
 
 	if instance.Spec.Appinfo.Appns != "" {
@@ -735,6 +731,10 @@ func (r *ReconcileChaosEngine) validateAnnontatedApplication(engine *chaosTypes.
 	}
 
 	if engine.Instance.Spec.AnnotationCheck == "true" {
+
+		if engine.AppInfo.Label == "" || engine.AppInfo.Namespace == "" || engine.AppInfo.Kind == "" {
+			return errors.Errorf("Incomplete AppInfo inside chaosengine")
+		}
 		// Determine whether apps with matching labels have chaos annotation set to true
 		engine, err = resource.CheckChaosAnnotation(engine, clientSet, *dynamicClient)
 		if err != nil {

--- a/pkg/controller/chaosengine/chaosengine_controller_test.go
+++ b/pkg/controller/chaosengine/chaosengine_controller_test.go
@@ -62,7 +62,7 @@ func TestInitializeApplicationInfo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			appInfo := &chaosTypes.ApplicationInfo{
 				Namespace: "namespace",
-				Label:     map[string]string{"fake_id": "aa"},
+				Label:     "fake_id=aa",
 				ExperimentList: []litmuschaosv1alpha1.ExperimentList{
 					{
 						Name: "fake_name",

--- a/pkg/controller/resource/resource_test.go
+++ b/pkg/controller/resource/resource_test.go
@@ -88,10 +88,8 @@ func TestCheckChaosAnnotationDeployment(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "deployment",
-					Label: map[string]string{
-						"app": "nginx1",
-					},
+					Kind:  "deployment",
+					Label: "app=nginx1",
 				},
 
 				AppExperiments: []string{"exp-1"},
@@ -149,10 +147,8 @@ func TestCheckChaosAnnotationDeployment(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "deployment",
-					Label: map[string]string{
-						"app": "nginx2",
-					},
+					Kind:  "deployment",
+					Label: "app=nginx2",
 				},
 				AppExperiments: []string{"exp-1"},
 			},
@@ -209,10 +205,8 @@ func TestCheckChaosAnnotationDeployment(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "deployment",
-					Label: map[string]string{
-						"app": "nginx3",
-					},
+					Kind:  "deployment",
+					Label: "app=nginx3",
 				},
 			},
 			isErr: true,
@@ -245,10 +239,8 @@ func TestCheckChaosAnnotationDeployment(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "deployment",
-					Label: map[string]string{
-						"app": "nginx4",
-					},
+					Kind:  "deployment",
+					Label: "app=nginx4",
 				},
 			},
 			deployment: []appv1.Deployment{
@@ -356,10 +348,8 @@ func TestCheckChaosAnnotationStatefulSet(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "statefulset",
-					Label: map[string]string{
-						"app": "nginx1",
-					},
+					Kind:  "statefulset",
+					Label: "app=nginx1",
 				},
 
 				AppExperiments: []string{"exp-1"},
@@ -417,10 +407,8 @@ func TestCheckChaosAnnotationStatefulSet(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "statefulset",
-					Label: map[string]string{
-						"app": "nginx2",
-					},
+					Kind:  "statefulset",
+					Label: "app=nginx2",
 				},
 
 				AppExperiments: []string{"exp-1"},
@@ -478,10 +466,8 @@ func TestCheckChaosAnnotationStatefulSet(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "statefulset",
-					Label: map[string]string{
-						"app": "nginx3",
-					},
+					Kind:  "statefulset",
+					Label: "app=nginx3",
 				},
 			},
 			isErr: true,
@@ -514,10 +500,8 @@ func TestCheckChaosAnnotationStatefulSet(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "statefulset",
-					Label: map[string]string{
-						"app": "nginx4",
-					},
+					Kind:  "statefulset",
+					Label: "app=nginx4",
 				},
 			},
 			statefulSet: []appv1.StatefulSet{
@@ -625,10 +609,8 @@ func TestCheckChaosAnnotationDaemonset(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "daemonset",
-					Label: map[string]string{
-						"app": "nginx1",
-					},
+					Kind:  "daemonset",
+					Label: "app=nginx1",
 				},
 
 				AppExperiments: []string{"exp-1"},
@@ -686,10 +668,8 @@ func TestCheckChaosAnnotationDaemonset(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "daemonset",
-					Label: map[string]string{
-						"app": "nginx2",
-					},
+					Kind:  "daemonset",
+					Label: "app=nginx2",
 				},
 
 				AppExperiments: []string{"exp-1"},
@@ -747,10 +727,8 @@ func TestCheckChaosAnnotationDaemonset(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "daemonset",
-					Label: map[string]string{
-						"app": "nginx3",
-					},
+					Kind:  "daemonset",
+					Label: "app=nginx3",
 				},
 			},
 			isErr: true,
@@ -783,10 +761,8 @@ func TestCheckChaosAnnotationDaemonset(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "daemonset",
-					Label: map[string]string{
-						"app": "nginx4",
-					},
+					Kind:  "daemonset",
+					Label: "app=nginx4",
 				},
 			},
 			daemonset: []appv1.DaemonSet{
@@ -894,10 +870,8 @@ func TestCheckChaosAnnotationDeploymentConfigs(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "deploymentconfig",
-					Label: map[string]string{
-						"app": "nginx1",
-					},
+					Kind:  "deploymentconfig",
+					Label: "app=nginx1",
 				},
 
 				AppExperiments: []string{"exp-1"},
@@ -956,10 +930,8 @@ func TestCheckChaosAnnotationDeploymentConfigs(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "deploymentconfig",
-					Label: map[string]string{
-						"app": "nginx2",
-					},
+					Kind:  "deploymentconfig",
+					Label: "app=nginx2",
 				},
 
 				AppExperiments: []string{"exp-1"},
@@ -1019,10 +991,8 @@ func TestCheckChaosAnnotationDeploymentConfigs(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "deploymentconfig",
-					Label: map[string]string{
-						"app": "nginx4",
-					},
+					Kind:  "deploymentconfig",
+					Label: "app=nginx4",
 				},
 			},
 			deploymentconfig: []unstructured.Unstructured{
@@ -1100,10 +1070,8 @@ func TestCheckChaosAnnotationDeploymentConfigs(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "deploymentconfig",
-					Label: map[string]string{
-						"app": "nginx3",
-					},
+					Kind:  "deploymentconfig",
+					Label: "app=nginx3",
 				},
 			},
 			isErr: true,
@@ -1180,10 +1148,8 @@ func TestCheckChaosAnnotationRollouts(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "rollout",
-					Label: map[string]string{
-						"app": "nginx1",
-					},
+					Kind:  "rollout",
+					Label: "app=nginx1",
 				},
 
 				AppExperiments: []string{"exp-1"},
@@ -1244,10 +1210,8 @@ func TestCheckChaosAnnotationRollouts(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "rollout",
-					Label: map[string]string{
-						"app": "nginx2",
-					},
+					Kind:  "rollout",
+					Label: "app=nginx2",
 				},
 
 				AppExperiments: []string{"exp-1"},
@@ -1309,10 +1273,8 @@ func TestCheckChaosAnnotationRollouts(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "rollout",
-					Label: map[string]string{
-						"app": "nginx4",
-					},
+					Kind:  "rollout",
+					Label: "app=nginx4",
 				},
 			},
 			rollout: []unstructured.Unstructured{
@@ -1394,10 +1356,8 @@ func TestCheckChaosAnnotationRollouts(t *testing.T) {
 					},
 				},
 				AppInfo: &chaosTypes.ApplicationInfo{
-					Kind: "rollout",
-					Label: map[string]string{
-						"app": "nginx3",
-					},
+					Kind:  "rollout",
+					Label: "app=nginx3",
 				},
 			},
 			isErr: true,

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -59,7 +59,7 @@ var (
 // ApplicationInfo contains the chaos details for target application
 type ApplicationInfo struct {
 	Namespace          string
-	Label              map[string]string
+	Label              string
 	ExperimentList     []litmuschaosv1alpha1.ExperimentList
 	ServiceAccountName string
 	Kind               string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

App Label can be used:
 - =
 - ==
 - !=
 - in
 - notin
 - exists

fixes: #334 

#### It supports all the standard kubernetes labels. For more details [refer](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#:~:text=Via%20a%20label%20selector%2C%20the,requirements%20which%20are%20comma%2Dseparated).
 
**Special notes for your reviewer**:
Have tested with labels.

Engine Specification
```
spec:
  appinfo:
    appns: 'sock-shop'
    applabel: 'app, name in (sock-shop, catalogue)'
    appkind: 'deployment'
  annotationCheck: 'true'
  engineState: 'active'
  chaosServiceAccount: litmus-admin
  monitoring: true
  jobCleanUpPolicy: 'retain'
  components:
    runner:
      imagePullPolicy: Always
```
Workflow result:
```
custom-chaos-workflow-1615274891   Succeeded   52m
``` 

**Checklist:**
-   [ ] Fixes #<issue number>
-   [x] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [x] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests