### PR TITLE
chore(terminationGracePeriodSeconds): Adding support for the termination grace period seconds

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -58,6 +58,8 @@ spec:
               pattern: ^(active|stop)$
             chaosServiceAccount:
               type: string
+            terminationGracePeriodSeconds:
+              type: integer
             components:
               type: object
               properties:
@@ -69,7 +71,7 @@ spec:
                     type:
                       type: string
                       pattern: ^(go)$
-                    runnerannotation:
+                    runnerAnnotations:
                       type: object
                       additionalProperties:
                         type: string
@@ -368,7 +370,7 @@ spec:
                                   type: string
                                 mountPath:
                                   type: string
-                          experimentannotation:
+                          experimentAnnotations:
                             type: object
                             additionalProperties:
                               type: string
@@ -379,8 +381,6 @@ spec:
                                 value:
                                   type: string
                                   minLength: 1
-
-
         status:
           type: object
   version: v1alpha1
@@ -579,7 +579,7 @@ spec:
                         type: array
                         items:
                           type: string
-                configmaps:
+                configMaps:
                   type: array
                   items:
                     type: object

--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -57,6 +57,8 @@ spec:
               pattern: ^(active|stop)$
             chaosServiceAccount:
               type: string
+            terminationGracePeriodSeconds:
+              type: integer
             components:
               type: object
               properties:
@@ -68,7 +70,7 @@ spec:
                     type:
                       type: string
                       pattern: ^(go)$
-                    runnerannotation:
+                    runnerAnnotations:
                       type: object
                       additionalProperties:
                         type: string
@@ -367,7 +369,7 @@ spec:
                                   type: string
                                 mountPath:
                                   type: string
-                          experimentannotation:
+                          experimentAnnotations:
                             type: object
                             additionalProperties:
                               type: string
@@ -380,8 +382,6 @@ spec:
                                   type: string
                                   minLength: 1
                                   allowEmptyValue: false
-
-
         status:
           type: object
   version: v1alpha1

--- a/deploy/crds/chaosexperiment_crd.yaml
+++ b/deploy/crds/chaosexperiment_crd.yaml
@@ -188,7 +188,7 @@ spec:
                         type: array
                         items:
                           type: string
-                configmaps:
+                configMaps:
                   type: array
                   items:
                     type: object

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -44,6 +44,8 @@ type ChaosEngineSpec struct {
 	AuxiliaryAppInfo string `json:"auxiliaryAppInfo,omitempty"`
 	//EngineStatus is a requirement for validation
 	EngineState EngineState `json:"engineState"`
+	// TerminationGracePeriodSeconds contains terminationGracePeriod for the chaos resources
+	TerminationGracePeriodSeconds int64 `json:"terminationGracePeriodSeconds,omitempty"`
 }
 
 // EngineState provides interface for all supported strings in spec.EngineState
@@ -140,7 +142,7 @@ type RunnerInfo struct {
 	//ImagePullSecrets for runner pod
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// Runner Annotations that needs to be provided in the pod for pod that is getting created
-	RunnerAnnotation map[string]string `json:"runnerannotation,omitempty"`
+	RunnerAnnotation map[string]string `json:"runnerAnnotations,omitempty"`
 	// NodeSelector for runner pod
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// ConfigMaps for runner pod
@@ -315,7 +317,7 @@ type ExperimentComponents struct {
 	ENV                        []corev1.EnvVar               `json:"env,omitempty"`
 	ConfigMaps                 []ConfigMap                   `json:"configMaps,omitempty"`
 	Secrets                    []Secret                      `json:"secrets,omitempty"`
-	ExperimentAnnotations      map[string]string             `json:"experimentannotation,omitempty"`
+	ExperimentAnnotations      map[string]string             `json:"experimentAnnotations,omitempty"`
 	ExperimentImage            string                        `json:"experimentImage,omitempty"`
 	ExperimentImagePullSecrets []corev1.LocalObjectReference `json:"experimentImagePullSecrets,omitempty"`
 	NodeSelector               map[string]string             `json:"nodeSelector,omitempty"`

--- a/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
@@ -54,9 +54,9 @@ type Secret struct {
 
 // HostFile is an simpler implementation of corev1.HostPath, needed for experiments
 type HostFile struct {
-	Name      string `json:"name"`
-	MountPath string `json:"mountPath"`
-	NodePath  string `json:"nodePath"`
+	Name      string              `json:"name"`
+	MountPath string              `json:"mountPath"`
+	NodePath  string              `json:"nodePath"`
 	Type      corev1.HostPathType `json:"type,omitempty"`
 }
 
@@ -80,13 +80,13 @@ type ExperimentDef struct {
 	// Defines arguments to runner's entrypoint command
 	Args []string `json:"args"`
 	// ConfigMaps contains a list of ConfigMaps
-	ConfigMaps []ConfigMap `json:"configmaps,omitempty"`
+	ConfigMaps []ConfigMap `json:"configMaps,omitempty"`
 	// Secrets contains a list of Secrets
 	Secrets []Secret `json:"secrets,omitempty"`
 	// HostFileVolume defines the host directory/file to be mounted
 	HostFileVolumes []HostFile `json:"hostFileVolumes,omitempty"`
 	// Annotations that needs to be provided in the pod for pod that is getting created
-	ExperimentAnnotations map[string]string `json:"experimentannotations,omitempty"`
+	ExperimentAnnotations map[string]string `json:"experimentAnnotations,omitempty"`
 	// SecurityContext holds security configuration that will be applied to a container
 	SecurityContext SecurityContext `json:"securityContext,omitempty"`
 	// HostPID is need to be provided in the chaospod

--- a/pkg/apis/litmuschaos/v1alpha1/chaosresult_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosresult_types.go
@@ -41,7 +41,7 @@ type ChaosResultStatus struct {
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
 	// ExperimentStatus contains the status,verdict of the experiment
-	ExperimentStatus TestStatus `json:"experimentstatus"`
+	ExperimentStatus TestStatus `json:"experimentStatus"`
 	// ProbeStatus contains the status of the probe
 	ProbeStatus []ProbeStatus `json:"probeStatus,omitempty"`
 	// History contains cumulative values of verdicts

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -498,6 +498,10 @@ func (r *ReconcileChaosEngine) reconcileForDelete(engine *chaosTypes.EngineInfo,
 // forceRemoveAllChaosPods force removes all chaos-related pods
 func (r *ReconcileChaosEngine) forceRemoveAllChaosPods(engine *chaosTypes.EngineInfo, request reconcile.Request) error {
 	optsDelete := []client.DeleteAllOfOption{client.InNamespace(request.NamespacedName.Namespace), client.MatchingLabels{"chaosUID": string(engine.Instance.UID)}, client.PropagationPolicy(metav1.DeletePropagationBackground)}
+	if engine.Instance.Spec.TerminationGracePeriodSeconds != 0 {
+		optsDelete = append(optsDelete, client.GracePeriodSeconds(engine.Instance.Spec.TerminationGracePeriodSeconds))
+	}
+
 	var deleteEvent []string
 	var err []error
 


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding support for the termination grace period seconds of the experiment & helper pod. Which can be provided at `.spec.experiments[*].spec.components.terminationGracePeriodSeconds` path inside chaosengine.
-  convert few other attributes from small case to the camel case

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests