### PR TITLE
chore(engineMonitoringType): Removed Monitoring field from ChaosEngine. 

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -29,8 +29,6 @@ spec:
         spec:
           type: object
           properties:
-            monitoring:
-              type: boolean
             jobCleanUpPolicy:
               type: string
               pattern: ^(delete|retain)$

--- a/deploy/crds/chaosengine_crd.yaml
+++ b/deploy/crds/chaosengine_crd.yaml
@@ -28,8 +28,6 @@ spec:
         spec:
           type: object
           properties:
-            monitoring:
-              type: boolean
             jobCleanUpPolicy:
               type: string
               pattern: ^(delete|retain)$

--- a/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -36,8 +36,6 @@ type ChaosEngineSpec struct {
 	Components ComponentParams `json:"components"`
 	//Consists of experiments executed by the engine
 	Experiments []ExperimentList `json:"experiments"`
-	//Monitor Enable Status
-	Monitoring bool `json:"monitoring,omitempty"`
 	//JobCleanUpPolicy decides to retain or delete the jobs
 	JobCleanUpPolicy CleanUpPolicy `json:"jobCleanUpPolicy,omitempty"`
 	//AuxiliaryAppInfo contains details of dependent applications (infra chaos)

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -381,7 +381,6 @@ func getApplicationDetail(engine *chaosTypes.EngineInfo) error {
 	chaosTypes.Log.Info("App Label derived from Chaosengine is ", "appLabelValue", chaosTypes.AppLabelValue)
 	chaosTypes.Log.Info("App NS derived from Chaosengine is ", "appNamespace", appInfo.Namespace)
 	chaosTypes.Log.Info("Exp list derived from chaosengine is ", "appExpirements", appExperiments)
-	chaosTypes.Log.Info("Monitoring Status derived from chaosengine is", "monitoringStatus", engine.Instance.Spec.Monitoring)
 	chaosTypes.Log.Info("Runner image derived from chaosengine is", "runnerImage", engine.Instance.Spec.Components.Runner.Image)
 	chaosTypes.Log.Info("Annotation check is ", "annotationCheck", engine.Instance.Spec.AnnotationCheck)
 	return nil

--- a/pkg/controller/chaosengine/chaosengine_controller_test.go
+++ b/pkg/controller/chaosengine/chaosengine_controller_test.go
@@ -236,7 +236,6 @@ func TestGetAnnotationCheck(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          true,
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
 							Applabel: "run=nginx",
 						},
@@ -262,7 +261,6 @@ func TestGetAnnotationCheck(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
 							Applabel: "run=nginx",
 						},
@@ -289,7 +287,6 @@ func TestGetAnnotationCheck(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						AnnotationCheck:     "fakeCheck",
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
 							Applabel: "run=nginx",
@@ -334,7 +331,6 @@ func TestValidateAnnontatedApplication(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						EngineState:         "active",
 						AnnotationCheck:     "false",
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
@@ -396,7 +392,6 @@ func TestValidateAnnontatedApplication(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
-						Monitoring:      true,
 						AnnotationCheck: "true",
 						EngineState:     "active",
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
@@ -648,7 +643,6 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          true,
 						Components: litmuschaosv1alpha1.ComponentParams{
 							Runner: litmuschaosv1alpha1.RunnerInfo{
 								Image: "fake-runner-image",
@@ -674,7 +668,6 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						Components: litmuschaosv1alpha1.ComponentParams{
 							Runner: litmuschaosv1alpha1.RunnerInfo{
 								Image:           "fake-runner-image",
@@ -702,7 +695,6 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						AnnotationCheck:     "false",
 						Components: litmuschaosv1alpha1.ComponentParams{
 							Runner: litmuschaosv1alpha1.RunnerInfo{
@@ -731,7 +723,6 @@ func TestNewGoRunnerPodForCR(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						AnnotationCheck:     "true",
 						Components: litmuschaosv1alpha1.ComponentParams{
 							Runner: litmuschaosv1alpha1.RunnerInfo{
@@ -1285,7 +1276,6 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          true,
 						Components: litmuschaosv1alpha1.ComponentParams{
 							Runner: litmuschaosv1alpha1.RunnerInfo{
 								Image: "fake-runner-image",
@@ -1307,7 +1297,6 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						Components: litmuschaosv1alpha1.ComponentParams{
 							Runner: litmuschaosv1alpha1.RunnerInfo{
 								Image: "fake-runner-image",
@@ -1330,7 +1319,6 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						AnnotationCheck:     "false",
 						Components: litmuschaosv1alpha1.ComponentParams{
 							Runner: litmuschaosv1alpha1.RunnerInfo{
@@ -1354,7 +1342,6 @@ func TestCheckEngineRunnerPod(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						AnnotationCheck:     "true",
 						Components: litmuschaosv1alpha1.ComponentParams{
 							Runner: litmuschaosv1alpha1.RunnerInfo{
@@ -1754,7 +1741,6 @@ func TestReconcileForCreationAndRunning(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          true,
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
 							Applabel: "run=nginx",
 						},
@@ -1785,7 +1771,6 @@ func TestReconcileForCreationAndRunning(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          false,
 						AnnotationCheck:     "fakeCheck",
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
 							Applabel: "run=nginx",
@@ -1811,7 +1796,6 @@ func TestReconcileForCreationAndRunning(t *testing.T) {
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
 						ChaosServiceAccount: "fake-serviceAccount",
-						Monitoring:          true,
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
 							Applabel: "run=nginx",
 						},

--- a/pkg/controller/resource/resource_test.go
+++ b/pkg/controller/resource/resource_test.go
@@ -68,7 +68,6 @@ func TestCheckChaosAnnotationDeployment(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
-						Monitoring:      false,
 						AnnotationCheck: "true",
 						EngineState:     "active",
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
@@ -328,7 +327,6 @@ func TestCheckChaosAnnotationStatefulSet(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
-						Monitoring:      false,
 						AnnotationCheck: "true",
 						EngineState:     "active",
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
@@ -589,7 +587,6 @@ func TestCheckChaosAnnotationDaemonset(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
-						Monitoring:      false,
 						AnnotationCheck: "true",
 						EngineState:     "active",
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
@@ -850,7 +847,6 @@ func TestCheckChaosAnnotationDeploymentConfigs(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
-						Monitoring:      false,
 						AnnotationCheck: "true",
 						EngineState:     "active",
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{
@@ -1128,7 +1124,6 @@ func TestCheckChaosAnnotationRollouts(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: litmuschaosv1alpha1.ChaosEngineSpec{
-						Monitoring:      false,
 						AnnotationCheck: "true",
 						EngineState:     "active",
 						Appinfo: litmuschaosv1alpha1.ApplicationParams{

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -234,7 +234,6 @@ var _ = Describe("BDD on chaos-operator", func() {
 						},
 					},
 					JobCleanUpPolicy: "retain",
-					Monitoring:       true,
 					EngineState:      "active",
 					Experiments: []v1alpha1.ExperimentList{
 						{
@@ -362,7 +361,6 @@ var _ = Describe("BDD on chaos-operator", func() {
 						},
 					},
 					JobCleanUpPolicy: "delete",
-					Monitoring:       true,
 					EngineState:      "active",
 					Experiments: []v1alpha1.ExperimentList{
 						{


### PR DESCRIPTION
Signed-off-by: Oum Kale <oumkale@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR: Monitoring will be independent of monitoring flag in engine. 

 Use : No need to pass flag to see Prometheus metrics for experiments.
  Files Updates:
 - chaos_crds.yaml
 - chaosengine_crd.yaml
 - chaosengine_types.go 
 - chaosengine_controller_test.go 
 - bdd_test.go 

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [x] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests