### PR TITLE
Added imagaPullPolicy to chaos experiment crd

### DIFF
--- a/deploy/chaos_crds.yaml
+++ b/deploy/chaos_crds.yaml
@@ -539,6 +539,8 @@ spec:
                     type: object
                 image:
                   type: string
+                imagePullPolicy:
+                  type: string
                 labels:
                   type: object
                   properties:

--- a/deploy/crds/chaosexperiment_crd.yaml
+++ b/deploy/crds/chaosexperiment_crd.yaml
@@ -150,6 +150,8 @@ spec:
                     type: object
                 image:
                   type: string
+                imagePullPolicy:
+                  type: string
                 labels:
                   type: object
                   properties:


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

**What this PR does / why we need it**:

This PR adds the missing `imagePullPolicy` attribute in the chaos experiment CRD

**Checklist:**
-   [x] Fixes Bug