### PR TITLE
feat(analytics): using same user-id for analytics even if operator pod restarts

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -48,13 +48,13 @@ func TriggerAnalytics() error {
 	if err != nil {
 		return fmt.Errorf("new client generation failed, error : %s", err)
 	}
-
-	if ClientUUID == "" {
-		return fmt.Errorf("uuid generation failed")
+	// sets the clientUUID to operator uid
+	ClientUUID, err = getUID()
+	if err != nil {
+		return err
 	}
 	client.ClientID(ClientUUID)
-	err = client.Send(ga.NewEvent(category, action).Label(label))
-	if err != nil {
+	if err := client.Send(ga.NewEvent(category, action).Label(label)); err != nil {
 		return fmt.Errorf("analytics event sending failed, error: %s", err)
 	}
 	return nil

--- a/pkg/controller/chaosengine/chaosengine_controller.go
+++ b/pkg/controller/chaosengine/chaosengine_controller.go
@@ -180,61 +180,25 @@ func (r *ReconcileChaosEngine) Reconcile(request reconcile.Request) (reconcile.R
 // getChaosRunnerENV return the env required for chaos-runner
 func getChaosRunnerENV(cr *litmuschaosv1alpha1.ChaosEngine, aExList []string, ClientUUID string) []corev1.EnvVar {
 
-	var appNS string
-
-	if cr.Spec.Appinfo.Appns != "" {
-		appNS = cr.Spec.Appinfo.Appns
-	} else {
+	appNS := cr.Spec.Appinfo.Appns
+	if appNS == "" {
 		appNS = cr.Namespace
 	}
 
-	return []corev1.EnvVar{
-		{
-			Name:  "CHAOSENGINE",
-			Value: cr.Name,
-		},
-		{
-			Name:  "APP_LABEL",
-			Value: cr.Spec.Appinfo.Applabel,
-		},
-		{
-			Name:  "APP_KIND",
-			Value: cr.Spec.Appinfo.AppKind,
-		},
-		{
-			Name:  "APP_NAMESPACE",
-			Value: appNS,
-		},
-		{
-			Name:  "EXPERIMENT_LIST",
-			Value: fmt.Sprint(strings.Join(aExList, ",")),
-		},
-		{
-			Name:  "CHAOS_SVC_ACC",
-			Value: cr.Spec.ChaosServiceAccount,
-		},
-		{
-			Name:  "AUXILIARY_APPINFO",
-			Value: cr.Spec.AuxiliaryAppInfo,
-		},
-		{
-			Name:  "CLIENT_UUID",
-			Value: ClientUUID,
-		},
-		{
-			Name:  "CHAOS_NAMESPACE",
-			Value: cr.Namespace,
-		},
-		{
-			Name:  "ANNOTATION_CHECK",
-			Value: cr.Spec.AnnotationCheck,
-		},
-		{
-			// we pass the key alone as we only support a boolean value for the annotation
-			Name:  "ANNOTATION_KEY",
-			Value: resource.GetAnnotationKey(),
-		},
-	}
+	var envDetails utils.ENVDetails
+	envDetails.SetEnv("CHAOSENGINE", cr.Name).
+		SetEnv("APP_LABEL", cr.Spec.Appinfo.Applabel).
+		SetEnv("APP_KIND", cr.Spec.Appinfo.AppKind).
+		SetEnv("APP_NAMESPACE", appNS).
+		SetEnv("EXPERIMENT_LIST", fmt.Sprint(strings.Join(aExList, ","))).
+		SetEnv("CHAOS_SVC_ACC", cr.Spec.ChaosServiceAccount).
+		SetEnv("AUXILIARY_APPINFO", cr.Spec.AuxiliaryAppInfo).
+		SetEnv("CLIENT_UUID", ClientUUID).
+		SetEnv("CHAOS_NAMESPACE", cr.Namespace).
+		SetEnv("ANNOTATION_CHECK", cr.Spec.AnnotationCheck).
+		SetEnv("ANNOTATION_KEY", resource.GetAnnotationKey())
+
+	return envDetails.ENV
 }
 
 // getChaosRunnerLabels return the labels required for chaos-runner

--- a/pkg/controller/utils/types.go
+++ b/pkg/controller/utils/types.go
@@ -41,3 +41,8 @@ type VolumeOpts struct {
 	VolumeMounts   []corev1.VolumeMount
 	VolumeBuilders []*volume.Builder
 }
+
+// ENVDetails contains the ENV details
+type ENVDetails struct {
+	ENV []corev1.EnvVar
+}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package utils
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
 // RemoveString removes a particular string from a slice of strings
 func RemoveString(slice []string, s string) (result []string) {
 	for _, item := range slice {
@@ -25,4 +29,15 @@ func RemoveString(slice []string, s string) (result []string) {
 		result = append(result, item)
 	}
 	return
+}
+
+// SetEnv sets the env inside envDetails struct
+func (envDetails *ENVDetails) SetEnv(key, value string) *ENVDetails {
+	if value != "" {
+		envDetails.ENV = append(envDetails.ENV, corev1.EnvVar{
+			Name:  key,
+			Value: value,
+		})
+	}
+	return envDetails
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

-  using the same user-id for analytics even if operator pod restarts
-  setting deployment UID as  clientUUID for analytics

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests