### PR TITLE
(enhancement)schema: additional statuses for result phase

### DIFF
--- a/api/litmuschaos/v1alpha1/chaosresult_types.go
+++ b/api/litmuschaos/v1alpha1/chaosresult_types.go
@@ -40,8 +40,10 @@ const (
 	ResultPhaseRunning ResultPhase = "Running"
 	// ResultPhaseCompleted is phase of chaosresult which is in completed state
 	ResultPhaseCompleted ResultPhase = "Completed"
-	// ResultPhaseCompletedWithError is phase of chaosresult when probe is failed
+	// Retained For Backward Compatibility: ResultPhaseCompletedWithError is phase of chaosresult when probe is failed in 3.0beta5
 	ResultPhaseCompletedWithError ResultPhase = "Completed_With_Error"
+	// ResultPhaseCompletedWithProbeFailure is phase of chaosresult when probe is failed from 3.0beta6
+	ResultPhaseCompletedWithProbeFailure ResultPhase = "Completed_With_Probe_Failure"
 	// ResultPhaseStopped is phase of chaosresult which is in stopped state
 	ResultPhaseStopped ResultPhase = "Stopped"
 	// ResultPhaseError is phase of chaosresult, which indicates that the experiment is terminated due to an error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

Adds a more appropriate status for chaos result upon probe failure within an experiment/fault. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests