### PR TITLE
enchancement: updated naming convention from clientSet to dynamicClient (#203)

### DIFF
--- a/pkg/client/dynamic/dynamic.go
+++ b/pkg/client/dynamic/dynamic.go
@@ -11,9 +11,9 @@ func CreateClientSet() (*dynamic.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	clientSet, err := dynamic.NewForConfig(restConfig)
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err
 	}
-	return &clientSet, nil
+	return &dynamicClient, nil
 }

--- a/pkg/client/kubernetes/kubernetes.go
+++ b/pkg/client/kubernetes/kubernetes.go
@@ -27,9 +27,9 @@ func CreateClientSet() (*kubernetes.Clientset, error) {
 	if err != nil {
 		return &kubernetes.Clientset{}, err
 	}
-	clientSet, err := kubernetes.NewForConfig(restConfig)
+	dynamicClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return &kubernetes.Clientset{}, err
 	}
-	return clientSet, nil
+	return dynamicClient, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the naming convention from **clientSet** to **dynamicClient**

**Which issue this PR fixes**
- Fixes #203 

**Special notes for your reviewer**:
- To verify the changes and check if everything is working fine. Just a sanity check.

**Checklist:**
-   [x] Fixes #203 
-   [x] PR messages has document related information